### PR TITLE
fix(tooltip): add reused tooltip component and fix focus steal on wayland

### DIFF
--- a/src/gui/collections_dialog.py
+++ b/src/gui/collections_dialog.py
@@ -39,6 +39,7 @@ from Utils.profile_state import (
 )
 from gui.install_mod import install_mod_from_archive, FOMOD_DEFERRED, ExtractionMemoryBudget, get_uncompressed_size
 from gui.mod_card import CARD_PAD, make_placeholder_image
+from gui.tk_tooltip import TkTooltip
 from Utils.ui_config import get_ui_scale
 from gui.mod_name_utils import _suggest_mod_names
 from Utils.modlist import write_modlist, read_modlist, ModEntry
@@ -619,52 +620,14 @@ class CollectionCard:
 
     def _attach_tooltip(self, widget: tk.Widget, text: str) -> None:
         """Attach a hover tooltip showing *text* to *widget* and all its children."""
-        self._tooltip_win: tk.Toplevel | None = None
-        self._tooltip_text = text
-
-        def _enter(event):
-            if self._tooltip_win is not None:
-                return
-            tw = tk.Toplevel(widget)
-            tw.withdraw()
-            tw.overrideredirect(True)
-            tw.attributes("-alpha", 0.95)
-            tw.configure(bg=BG_DEEP)
-            wrap = min(scaled(340), scaled(int(self._coll_w * 1.4)))
-            tk.Label(
-                tw, text=self._tooltip_text,
-                bg=BG_DEEP, fg=TEXT_MAIN,
-                font=FONT_SMALL,
-                wraplength=wrap, justify="left",
-                padx=scaled(8), pady=scaled(6),
-            ).pack()
-            # Position near cursor, keep on-screen
-            x = event.x_root + scaled(12)
-            y = event.y_root + scaled(12)
-            tw.update_idletasks()
-            sw = tw.winfo_screenwidth()
-            sh = tw.winfo_screenheight()
-            if x + tw.winfo_reqwidth() > sw:
-                x = event.x_root - tw.winfo_reqwidth() - scaled(4)
-            if y + tw.winfo_reqheight() > sh:
-                y = event.y_root - tw.winfo_reqheight() - scaled(4)
-            tw.geometry(f"+{x}+{y}")
-            tw.deiconify()
-            self._tooltip_win = tw
-
-        def _leave(event):
-            if self._tooltip_win:
-                self._tooltip_win.destroy()
-                self._tooltip_win = None
-
-        def _bind_recursive(w: tk.Widget, depth=0) -> None:
-            w.bind("<Enter>", _enter, add="+")
-            w.bind("<Leave>", _leave, add="+")
-            if depth < 3:
-                for child in w.winfo_children():
-                    _bind_recursive(child, depth + 1)
-
-        _bind_recursive(widget)
+        wrap = min(scaled(340), scaled(int(self._coll_w * 1.4)))
+        self._tooltip = TkTooltip(
+            widget,
+            bg=BG_DEEP, fg=TEXT_MAIN, font=FONT_SMALL,
+            wraplength=wrap, padx=scaled(8), pady=scaled(6),
+            alpha=0.95,
+        )
+        self._tooltip.attach(widget, text, offset_x=scaled(12), offset_y=scaled(12))
 
 
 # ---------------------------------------------------------------------------

--- a/src/gui/mod_card.py
+++ b/src/gui/mod_card.py
@@ -29,6 +29,7 @@ from gui.theme import (
     FONT_FAMILY,
     scaled,
 )
+from gui.tk_tooltip import TkTooltip
 
 # Card dimensions (shared with browse)
 # CARD_W / CARD_H are passed to CTkFrame (which applies its own widget scaling),
@@ -290,49 +291,14 @@ class ModCard:
 
     def _attach_tooltip(self, text: str) -> None:
         """Attach a hover tooltip showing the mod summary to the card."""
-        self._tooltip_win: tk.Toplevel | None = None
-
-        def _enter(event):
-            if self._tooltip_win is not None:
-                return
-            tw = tk.Toplevel(self.card)
-            tw.withdraw()
-            tw.overrideredirect(True)
-            tw.attributes("-alpha", 0.95)
-            tw.configure(bg=BG_DEEP)
-            tk.Label(
-                tw, text=text,
-                bg=BG_DEEP, fg=TEXT_MAIN,
-                font=font_sized(FONT_FAMILY, 11),
-                wraplength=scaled(320), justify="left",
-                padx=scaled(8), pady=scaled(6),
-            ).pack()
-            x = event.x_root + scaled(12)
-            y = event.y_root + scaled(12)
-            tw.update_idletasks()
-            sw = tw.winfo_screenwidth()
-            sh = tw.winfo_screenheight()
-            if x + tw.winfo_reqwidth() > sw:
-                x = event.x_root - tw.winfo_reqwidth() - scaled(4)
-            if y + tw.winfo_reqheight() > sh:
-                y = event.y_root - tw.winfo_reqheight() - scaled(4)
-            tw.geometry(f"+{x}+{y}")
-            tw.deiconify()
-            self._tooltip_win = tw
-
-        def _leave(event):
-            if self._tooltip_win:
-                self._tooltip_win.destroy()
-                self._tooltip_win = None
-
-        def _bind_recursive(w, depth=0) -> None:
-            w.bind("<Enter>", _enter, add="+")
-            w.bind("<Leave>", _leave, add="+")
-            if depth < 3:
-                for child in w.winfo_children():
-                    _bind_recursive(child, depth + 1)
-
-        _bind_recursive(self.card)
+        self._tooltip = TkTooltip(
+            self.card,
+            bg=BG_DEEP, fg=TEXT_MAIN,
+            font=font_sized(FONT_FAMILY, 11),
+            wraplength=scaled(320), padx=scaled(8), pady=scaled(6),
+            alpha=0.95,
+        )
+        self._tooltip.attach(self.card, text, offset_x=scaled(12), offset_y=scaled(12))
 
     def _apply_image(self, photo: ctk.CTkImage):
         if self._img_label.winfo_exists():

--- a/src/gui/modlist_panel.py
+++ b/src/gui/modlist_panel.py
@@ -138,6 +138,7 @@ from Nexus.nexus_update_checker import check_for_updates
 
 
 from gui.text_utils import truncate_text as _truncate_text_for_width, clear_truncate_cache as _clear_truncate_cache
+from gui.tk_tooltip import TkTooltip
 
 
 def _scan_meta_flags_impl(entries: list, mods_dir: Path) -> dict:
@@ -342,8 +343,12 @@ class ModListPanel(ctk.CTkFrame):
         self._ignored_missing_reqs: set[str] = set()
 
         # Tooltip state (missing requirements hover)
-        self._tooltip_win: tk.Toplevel | None = None
-        self._tooltip_text: str = ""
+        self._tooltip = TkTooltip(
+            self,
+            bg="#1a1a2e",
+            fg="#ff6b6b",
+            font=(_theme.FONT_FAMILY, _theme.FS10),
+        )
 
         # Set of mod names the user has endorsed on Nexus
         self._endorsed_mods: set[str] = set()
@@ -4506,44 +4511,10 @@ class ModListPanel(ctk.CTkFrame):
         self._redraw()
         self._update_info()
 
-    # ------------------------------------------------------------------
-    # Tooltip for missing requirements
-    # ------------------------------------------------------------------
-
-    def _show_tooltip(self, x: int, y: int, text: str) -> None:
-        """Show a tooltip window near the given screen coordinates."""
-        if self._tooltip_win is not None and self._tooltip_text == text:
-            return
-        self._hide_tooltip()
-        tw = tk.Toplevel(self)
-        tw.withdraw()
-        tw.wm_overrideredirect(True)
-        tw.configure(bg="#1a1a2e")
-        lbl = tk.Label(
-            tw, text=text, justify="left",
-            bg="#1a1a2e", fg="#ff6b6b",
-            font=(_theme.FONT_FAMILY, _theme.FS10), padx=8, pady=4,
-            wraplength=350,
-        )
-        lbl.pack()
-        tw.update_idletasks()
-        tip_w = tw.winfo_reqwidth()
-        tip_x = x - tip_w - 4
-        tw.wm_geometry(f"+{tip_x}+{y + 8}")
-        tw.deiconify()
-        self._tooltip_win = tw
-        self._tooltip_text = text
-
-    def _hide_tooltip(self) -> None:
-        if self._tooltip_win:
-            self._tooltip_win.destroy()
-            self._tooltip_win = None
-            self._tooltip_text = ""
-
     def _on_mouse_motion(self, event):
         """Update hover highlight as the mouse moves over the modlist."""
         if not self._entries or self._drag_idx >= 0:
-            self._hide_tooltip()
+            self._tooltip.hide()
             return
         cy = self._event_canvas_y(event)
         vis = self._visible_indices
@@ -4611,7 +4582,7 @@ class ModListPanel(ctk.CTkFrame):
                     # Find which icon the cursor is closest to (within hit radius)
                     for _fx, tip in _flag_tooltips:
                         if abs(x - _fx) <= _HIT_RADIUS:
-                            self._show_tooltip(event.x_root, event.y_root, tip)
+                            self._tooltip.show(event.x_root, event.y_root, tip)
                             return
                     # Cursor is in the flags column but not over a specific icon —
                     # keep any existing tooltip rather than flashing it away
@@ -4646,14 +4617,14 @@ class ModListPanel(ctk.CTkFrame):
                         tip = f"Loose file conflict - {_conflict_label[loose]}"
                     else:
                         tip = f"BSA conflict - {_conflict_label[bsa]}"
-                    self._show_tooltip(event.x_root, event.y_root, tip)
+                    self._tooltip.show(event.x_root, event.y_root, tip)
                     return
 
-        self._hide_tooltip()
+        self._tooltip.hide()
 
     def _on_mouse_leave(self, event):
         """Clear hover highlight when mouse leaves the canvas."""
-        self._hide_tooltip()
+        self._tooltip.hide()
         if self._hover_idx != -1:
             self._hover_idx = -1
             self._redraw()

--- a/src/gui/plugin_panel.py
+++ b/src/gui/plugin_panel.py
@@ -121,6 +121,7 @@ def _read_prefix_runner(compat_data: Path) -> str:
 
 
 from gui.text_utils import truncate_text as _truncate_plugin_name, clear_truncate_cache as _clear_truncate_cache
+from gui.tk_tooltip import TkTooltip
 
 
 # ---------------------------------------------------------------------------
@@ -272,7 +273,12 @@ class PluginPanel(ctk.CTkFrame):
                 PilImage.open(_lock_path).convert("RGBA").resize((_lk_sz, _lk_sz), PilImage.LANCZOS))
 
         # Tooltip state
-        self._tooltip_win: tk.Toplevel | None = None
+        self._tooltip = TkTooltip(
+            self,
+            bg="#1a1a2e",
+            fg="#ff6b6b",
+            font=(_theme.FONT_FAMILY, _theme.FS10),
+        )
 
         # Canvas column x-positions (patched in _layout_plugin_cols)
         self._pcol_x = [scaled(4), scaled(32), 0, 0, 0]  # checkbox, name, flags, lock, index
@@ -5268,37 +5274,6 @@ class PluginPanel(ctk.CTkFrame):
         self._esl_safe_plugins = safe
         self._esl_unsafe_plugins = unsafe
 
-    # ------------------------------------------------------------------
-    # Tooltip for missing masters
-    # ------------------------------------------------------------------
-
-    def _show_tooltip(self, x: int, y: int, text: str) -> None:
-        """Show a tooltip window near the given screen coordinates."""
-        self._hide_tooltip()
-        tw = tk.Toplevel(self)
-        tw.withdraw()
-        tw.wm_overrideredirect(True)
-        tw.configure(bg="#1a1a2e")
-        lbl = tk.Label(
-            tw, text=text, justify="left",
-            bg="#1a1a2e", fg="#ff6b6b",
-            font=(_theme.FONT_FAMILY, _theme.FS10), padx=8, pady=4,
-            wraplength=350,
-        )
-        lbl.pack()
-        tw.update_idletasks()
-        tip_w = tw.winfo_reqwidth()
-        # Always place to the left of the cursor (flags column is at the right edge)
-        tip_x = x - tip_w - 4
-        tw.wm_geometry(f"+{tip_x}+{y + 8}")
-        tw.deiconify()
-        self._tooltip_win = tw
-
-    def _hide_tooltip(self) -> None:
-        if self._tooltip_win:
-            self._tooltip_win.destroy()
-            self._tooltip_win = None
-
     def _update_row_bg(self, data_row: int) -> None:
         """Update just the background colour of a single data row's pool slot."""
         fi = self._plugin_filtered_indices
@@ -5350,7 +5325,7 @@ class PluginPanel(ctk.CTkFrame):
         fi = self._plugin_filtered_indices
         view_len = len(fi) if fi is not None else len(self._plugin_entries)
         if row < 0 or row >= view_len:
-            self._hide_tooltip()
+            self._tooltip.hide()
             if self._phover_idx != -1:
                 old = self._phover_idx
                 self._phover_idx = -1
@@ -5387,22 +5362,15 @@ class PluginPanel(ctk.CTkFrame):
             if entry.name.lower() in self._esl_flagged_plugins:
                 parts.append("This plugin is marked as Light (ESL)")
             if parts:
-                screen_x = event.x_root
-                screen_y = event.y_root
                 text = "\n\n".join(parts)
-                # Always refresh: show_tooltip hides the old one first, so moving
-                # between rows/flags updates immediately instead of staying stale.
-                if self._tooltip_win is None or getattr(self, "_tooltip_text", None) != text:
-                    self._tooltip_text = text
-                    self._show_tooltip(screen_x, screen_y, text)
+                # TkTooltip.show() is idempotent for the same text — no stale check needed.
+                self._tooltip.show(event.x_root, event.y_root, text)
                 return
 
-        self._hide_tooltip()
-        self._tooltip_text = None
+        self._tooltip.hide()
 
     def _on_pmouse_leave(self, event) -> None:
-        self._hide_tooltip()
-        self._tooltip_text = None
+        self._tooltip.hide()
         if self._phover_idx != -1:
             old = self._phover_idx
             self._phover_idx = -1

--- a/src/gui/tk_tooltip.py
+++ b/src/gui/tk_tooltip.py
@@ -1,0 +1,225 @@
+"""
+Tooltip helper for plain tkinter widgets — compatible with X11 and Wayland.
+
+**Canvas / manual mode** — call :meth:`show` / :meth:`hide` directly::
+
+    tip = TkTooltip(parent_widget, bg="#1a1a2e", fg="#ff6b6b")
+    tip.show(event.x_root, event.y_root, "Some text")   # debounced
+    tip.hide()
+
+**Widget-binding mode** — call :meth:`attach` once and let it manage
+``<Enter>`` / ``<Leave>`` bindings automatically::
+
+    tip = TkTooltip(parent, bg=BG, fg=FG, font=FONT, alpha=0.95)
+    tip.attach(some_widget, "Tooltip text")
+"""
+
+import tkinter as tk
+
+
+class TkTooltip:
+    """Debounced tooltip for plain tkinter widgets, compatible with X11 and Wayland.
+
+    **X11**: ``overrideredirect`` and client-side ``wm_geometry`` positioning
+    are natively supported; the ``-type tooltip`` EWMH hint is honoured by all
+    major window managers (i3, Openbox, KDE, GNOME, XFWM, …).
+
+    **Wayland / XWayland** (e.g. Hyprland): a plain ``Toplevel`` with
+    ``overrideredirect(True)`` can steal keyboard focus, firing a ``<Leave>``
+    event on the host widget and instantly destroying the tooltip — causing
+    visible flicker.  This class fixes the problem by:
+
+    * Declaring the window as ``-type tooltip`` so the compositor never
+      gives it focus (wrapped in ``try/except`` for portability).
+    * Delaying creation until the cursor has been stationary for
+      *delay_ms* milliseconds, which also prevents rapid create/destroy
+      cycles on fast mouse motion.
+    * Ignoring motion within a *jitter*-pixel radius of the trigger point
+      so the tooltip stays stable while the cursor moves inside an element.
+    """
+
+    def __init__(
+        self,
+        parent: tk.Widget,
+        *,
+        bg: str = "#1a1a2e",
+        fg: str = "#ff6b6b",
+        font: tuple = ("TkDefaultFont", 10),
+        wraplength: int = 350,
+        padx: int = 8,
+        pady: int = 4,
+        alpha: float = 1.0,
+        delay_ms: int = 400,
+        jitter: int = 8,
+    ) -> None:
+        self._parent = parent
+        self._bg = bg
+        self._fg = fg
+        self._font = font
+        self._wraplength = wraplength
+        self._padx = padx
+        self._pady = pady
+        self._alpha = alpha
+        self._delay_ms = delay_ms
+        self._jitter = jitter
+
+        self._win = None
+        self._text: str = ""
+        self._after_id = None
+        self._trigger_x: int = 0
+        self._trigger_y: int = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def show(self, x: int, y: int, text: str) -> None:
+        """Schedule the tooltip to appear at screen coords (*x*, *y*).
+
+        Placement: to the left of the cursor (suits canvas column icons).
+        Mouse movement within *jitter* pixels of the trigger point with the
+        same text is ignored so the tooltip stays stable inside an element.
+        """
+        if (self._text == text
+                and abs(x - self._trigger_x) <= self._jitter
+                and abs(y - self._trigger_y) <= self._jitter):
+            return
+
+        if self._after_id is not None:
+            self._parent.after_cancel(self._after_id)
+            self._after_id = None
+
+        if self._win is not None:
+            self._win.destroy()
+            self._win = None
+
+        self._text = text
+        self._trigger_x = x
+        self._trigger_y = y
+
+        def _do_show() -> None:
+            self._after_id = None
+            tw = self._make_window(text)
+            tw.update_idletasks()
+            tip_w = tw.winfo_reqwidth()
+            tw.wm_geometry(f"+{x - tip_w - 4}+{y + 8}")
+            tw.deiconify()
+            self._win = tw
+
+        self._after_id = self._parent.after(self._delay_ms, _do_show)
+
+    def attach(
+        self,
+        widget: tk.Widget,
+        text: str,
+        *,
+        recursive_depth: int = 3,
+        offset_x: int = 12,
+        offset_y: int = 12,
+    ) -> None:
+        """Bind *widget* (and its children) so the tooltip appears on hover.
+
+        Placement: right/below the cursor with screen-edge clamping.
+        Applies the same Wayland-safe debounced creation as :meth:`show`.
+
+        Parameters
+        ----------
+        widget:
+            The root widget to bind.
+        text:
+            Tooltip content.
+        recursive_depth:
+            How many levels of children to also bind (default 3).
+        offset_x / offset_y:
+            Pixel offset from the cursor when the tooltip appears.
+        """
+        def _enter(event: tk.Event) -> None:
+            if self._win is not None and self._text == text:
+                return
+            if self._after_id is not None:
+                self._parent.after_cancel(self._after_id)
+                self._after_id = None
+            if self._win is not None:
+                self._win.destroy()
+                self._win = None
+                self._text = ""
+            rx, ry = event.x_root, event.y_root
+
+            def _do_show() -> None:
+                self._after_id = None
+                tw = self._make_window(text)
+                tw.update_idletasks()
+                w = tw.winfo_reqwidth()
+                h = tw.winfo_reqheight()
+                sw = tw.winfo_screenwidth()
+                sh = tw.winfo_screenheight()
+                x = rx + offset_x
+                y = ry + offset_y
+                if x + w > sw:
+                    x = rx - w - offset_x
+                if y + h > sh:
+                    y = ry - h - offset_y
+                tw.wm_geometry(f"+{x}+{y}")
+                tw.deiconify()
+                self._win = tw
+                self._text = text
+
+            self._after_id = self._parent.after(self._delay_ms, _do_show)
+
+        def _leave(event: tk.Event) -> None:
+            self.hide()
+
+        def _bind_recursive(w: tk.Widget, depth: int = 0) -> None:
+            w.bind("<Enter>", _enter, add="+")
+            w.bind("<Leave>", _leave, add="+")
+            if depth < recursive_depth:
+                for child in w.winfo_children():
+                    _bind_recursive(child, depth + 1)
+
+        _bind_recursive(widget)
+
+    def hide(self) -> None:
+        """Cancel any pending show and destroy the tooltip window."""
+        if self._after_id is not None:
+            self._parent.after_cancel(self._after_id)
+            self._after_id = None
+        if self._win is not None:
+            self._win.destroy()
+            self._win = None
+        self._text = ""
+        self._trigger_x = 0
+        self._trigger_y = 0
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _make_window(self, text: str) -> tk.Toplevel:
+        """Create and return a withdrawn, decorated Toplevel (not yet placed)."""
+        tw = tk.Toplevel(self._parent)
+        tw.withdraw()
+        tw.wm_overrideredirect(True)
+        # Tell Wayland/XWayland compositors this is a tooltip so it is
+        # never given input focus (prevents Leave-event flicker on Hyprland).
+        try:
+            tw.wm_attributes("-type", "tooltip")
+        except tk.TclError:
+            pass
+        if self._alpha < 1.0:
+            try:
+                tw.wm_attributes("-alpha", self._alpha)
+            except tk.TclError:
+                pass
+        tw.configure(bg=self._bg)
+        tk.Label(
+            tw,
+            text=text,
+            justify="left",
+            bg=self._bg,
+            fg=self._fg,
+            font=self._font,
+            padx=self._padx,
+            pady=self._pady,
+            wraplength=self._wraplength,
+        ).pack()
+        return tw


### PR DESCRIPTION
This pull request introduces a new `TkTooltip` helper class for tooltips in Tkinter GUIs and refactors all tooltip implementations across the codebase to use this unified, Wayland/X11-safe solution. The result is more consistent tooltip behavior, reduced code duplication, and improved compatibility with modern Linux compositors.

The most important changes are:

**New Feature:**
* Added `TkTooltip` class in `src/gui/tk_tooltip.py`, providing a debounced, flicker-free tooltip implementation compatible with both X11 and Wayland environments, with a unified API for both manual and widget-binding modes.

**Refactoring: Tooltip Integration**
* Replaced all custom tooltip logic in `src/gui/mod_card.py`, `src/gui/collections_dialog.py`, `src/gui/modlist_panel.py`, and `src/gui/plugin_panel.py` with the new `TkTooltip` class, significantly reducing duplicated code and centralizing tooltip behavior. [[1]](diffhunk://#diff-55945e7f677ad72200d68e1e03988aca3f36d9b7526d1dc867de03750503c70eL293-R301) [[2]](diffhunk://#diff-c429f6c3415834cd7fb39ebd400f82c34491ce5f39724c0e48c107cd0b3f41f5L622-R630) [[3]](diffhunk://#diff-9de91c224479b00fbb1a121156d0ff28f3ff959af47abda74d4f5b49bb51fd9dL345-R351) [[4]](diffhunk://#diff-8cf54f1bfb6720ce69ffd823390b49b57e9d32489058671f15794d8158f6365cL275-R281)
* Updated tooltip event handling in modlist and plugin panels to use `TkTooltip.show()` and `TkTooltip.hide()` instead of manual `Toplevel` management, ensuring consistent appearance and debouncing. [[1]](diffhunk://#diff-9de91c224479b00fbb1a121156d0ff28f3ff959af47abda74d4f5b49bb51fd9dL4509-R4517) [[2]](diffhunk://#diff-8cf54f1bfb6720ce69ffd823390b49b57e9d32489058671f15794d8158f6365cL5271-L5301) [[3]](diffhunk://#diff-9de91c224479b00fbb1a121156d0ff28f3ff959af47abda74d4f5b49bb51fd9dL4614-R4585) [[4]](diffhunk://#diff-9de91c224479b00fbb1a121156d0ff28f3ff959af47abda74d4f5b49bb51fd9dL4649-R4627) [[5]](diffhunk://#diff-8cf54f1bfb6720ce69ffd823390b49b57e9d32489058671f15794d8158f6365cL5353-R5328) [[6]](diffhunk://#diff-8cf54f1bfb6720ce69ffd823390b49b57e9d32489058671f15794d8158f6365cL5390-R5373)

**Imports and Initialization**
* Added imports for `TkTooltip` in all relevant files (`mod_card.py`, `collections_dialog.py`, `modlist_panel.py`, `plugin_panel.py`) and initialized a `TkTooltip` instance in each class where tooltips are used. [[1]](diffhunk://#diff-55945e7f677ad72200d68e1e03988aca3f36d9b7526d1dc867de03750503c70eR32) [[2]](diffhunk://#diff-c429f6c3415834cd7fb39ebd400f82c34491ce5f39724c0e48c107cd0b3f41f5R42) [[3]](diffhunk://#diff-9de91c224479b00fbb1a121156d0ff28f3ff959af47abda74d4f5b49bb51fd9dR141) [[4]](diffhunk://#diff-8cf54f1bfb6720ce69ffd823390b49b57e9d32489058671f15794d8158f6365cR124)

This refactor improves maintainability and ensures tooltips behave reliably across all supported platforms.