### PR TITLE
Handle differing wine paths on Proton 11+

### DIFF
--- a/src/Utils/steam_finder.py
+++ b/src/Utils/steam_finder.py
@@ -585,3 +585,21 @@ def find_game_in_libraries(libraries: list[Path], exe_name: str) -> Path | None:
             continue
 
     return None
+
+
+def find_wine() -> tuple[str, Path]:
+    """
+    Finds a wine binary and the Proton root.
+    This will first search for wine64 (Proton 9, 10), then fallback to wine (Proton 11+).
+    Returns (wine_path_str, proton_files_dir).
+    """
+    proton_script = find_any_installed_proton()
+    if proton_script is None:
+        raise RuntimeError("No Proton/Wine installation found. Install proton via Steam.")
+    files_dir = proton_script.parent / "files"
+    wine = files_dir / "bin" / "wine64"
+    if not wine.is_file():
+        wine = files_dir / "bin" / "wine"
+        if not wine.is_file():
+            raise RuntimeError(f"wine/wine64 not found at expected path in {files_dir / 'bin'}")
+    return str(wine), files_dir

--- a/src/wrappers/bendr.py
+++ b/src/wrappers/bendr.py
@@ -26,7 +26,7 @@ from typing import Callable
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\[[?][0-9;]*[A-Za-z]|\x1b[A-Za-z]|\r")
 
 from Utils.config_paths import get_download_cache_dir
-from Utils.steam_finder import find_any_installed_proton
+from Utils.steam_finder import find_wine
 from wrappers.vramr import _ensure_compressonator, _optimise_one_texture
 
 
@@ -35,17 +35,6 @@ from wrappers.vramr import _ensure_compressonator, _optimise_one_texture
 def _linux_to_wine(path: str | Path) -> str:
     r"""Convert a Linux absolute path to a Wine Z:\ drive path."""
     return "Z:" + str(path).replace("/", "\\")
-
-
-def _find_wine() -> str:
-    """Locate a wine64 binary from a Proton installation."""
-    proton_script = find_any_installed_proton()
-    if proton_script is None:
-        raise RuntimeError("No Proton/Wine installation found. Install Proton via Steam.")
-    wine = proton_script.parent / "files" / "bin" / "wine64"
-    if not wine.is_file():
-        raise RuntimeError(f"wine64 not found at expected path: {wine}")
-    return str(wine)
 
 
 def _wine_run(
@@ -281,7 +270,7 @@ def run_bendr(
 
     # Discover Wine
     _log("BENDr: Locating Proton/Wine...")
-    wine = _find_wine()
+    wine = find_wine()[0]
     prefix = str(get_download_cache_dir() / "wine_prefixes" / "bendr")
     Path(prefix).mkdir(parents=True, exist_ok=True)
     _log(f"  Wine: {wine}")

--- a/src/wrappers/parallaxr.py
+++ b/src/wrappers/parallaxr.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Callable
 
 from Utils.config_paths import get_download_cache_dir
-from Utils.steam_finder import find_any_installed_proton
+from Utils.steam_finder import find_wine
 from wrappers.bendr import _linux_to_wine, _ensure_utf8_prefix
 
 import re
@@ -29,21 +29,6 @@ import select
 import subprocess
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\[[?][0-9;]*[A-Za-z]|\x1b[A-Za-z]|\r")
-
-
-def _find_wine() -> tuple[str, Path]:
-    """Locate a wine64 binary and the Proton root from any installed Proton.
-
-    Returns (wine64_path_str, proton_files_dir).
-    """
-    proton_script = find_any_installed_proton()
-    if proton_script is None:
-        raise RuntimeError("No Proton/Wine installation found. Install Proton via Steam.")
-    files_dir = proton_script.parent / "files"
-    wine = files_dir / "bin" / "wine64"
-    if not wine.is_file():
-        raise RuntimeError(f"wine64 not found at expected path: {wine}")
-    return str(wine), files_dir
 
 
 def _build_wine_overlay(proton_files_dir: Path, patched_ucrtbase: Path) -> Path:
@@ -75,7 +60,7 @@ def _build_wine_overlay(proton_files_dir: Path, patched_ucrtbase: Path) -> Path:
     proton_wine_unix = proton_files_dir / "lib" / "wine" / "x86_64-unix"
 
     # Copy binaries (must be real files so Wine resolves paths to our overlay)
-    for name in ("wine64", "wine64-preloader", "wineserver"):
+    for name in ("wine64", "wine64-preloader", "wine", "wine-preloader", "wineserver"):
         src = proton_bin / name
         if src.is_file():
             shutil.copy2(str(src), str(bin_dir / name))
@@ -272,7 +257,8 @@ def run_parallaxr(
 
     # Discover Wine
     _log("ParallaxR: Locating Proton/Wine...")
-    _, proton_files_dir = _find_wine()
+    wine_path, proton_files_dir = find_wine()
+    wine_name = Path(wine_path).name
     prefix = str(get_download_cache_dir() / "wine_prefixes" / "parallaxr")
     Path(prefix).mkdir(parents=True, exist_ok=True)
 
@@ -285,7 +271,7 @@ def run_parallaxr(
         )
     _log("ParallaxR: Building Wine overlay...")
     overlay = _build_wine_overlay(proton_files_dir, patched_ucrtbase)
-    wine = str(overlay / "bin" / "wine64")
+    wine = str(overlay / "bin" / wine_name)
     _log(f"  Wine: {wine}")
 
     # Set WINEDLLPATH before prefix init so the wineserver starts with it.

--- a/src/wrappers/vramr.py
+++ b/src/wrappers/vramr.py
@@ -32,7 +32,7 @@ from typing import Callable
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\[[?][0-9;]*[A-Za-z]|\x1b[A-Za-z]|\r")
 
 from Utils.config_paths import get_config_dir, get_download_cache_dir
-from Utils.steam_finder import find_any_installed_proton
+from Utils.steam_finder import find_wine
 
 
 # ── Presets ────────────────────────────────────────────────────────────────
@@ -65,17 +65,6 @@ _COMPRESSONATOR_DIR_NAME = "compressonatorcli-4.5.52-Linux"
 def _linux_to_wine(path: str | Path) -> str:
     r"""Convert a Linux absolute path to a Wine Z:\ drive path."""
     return "Z:" + str(path).replace("/", "\\")
-
-
-def _find_wine() -> str:
-    """Locate a wine64 binary from a Proton installation."""
-    proton_script = find_any_installed_proton()
-    if proton_script is None:
-        raise RuntimeError("No Proton/Wine installation found. Install Proton via Steam.")
-    wine = proton_script.parent / "files" / "bin" / "wine64"
-    if not wine.is_file():
-        raise RuntimeError(f"wine64 not found at expected path: {wine}")
-    return str(wine)
 
 
 def _wine_run(
@@ -441,7 +430,7 @@ def run_vramr(
 
     # Discover Wine
     _log("Locating Proton/Wine...")
-    wine = _find_wine()
+    wine = find_wine()[0]
     prefix = str(get_download_cache_dir() / "wine_prefixes" / "vramr")
     Path(prefix).mkdir(parents=True, exist_ok=True)
     _log(f"  Wine: {wine}")


### PR DESCRIPTION
Proton 11 updated the wow64 architecture and this removes wine64. This caused VRAMr, BENDr, and ParalaxR wizards to crash when it tried to find the the wine executable.

This PR unifies the _find_wine logic from the wizards into the steam finder utils folder as find_wine. The behavior of this utility has been changed to check for wine64 (for keeping old proton compatability) first and then to fallback to wine if it isn't found. I also updated paralaxr's overlay builder to grab the correct executable name and copy both wine and wine-reloader to the temporary overlay.

This is my first time writing python in a while, I might have missed something.