### PR TITLE
Add Skygen Base Object Swapper/Skypatcher INI Generator to Amethyst Mod Manager

### DIFF
--- a/src/Games/Bethesda/Bethesda.py
+++ b/src/Games/Bethesda/Bethesda.py
@@ -1199,6 +1199,21 @@ class Skyrim(Fallout_3):
                 description="Download and run Wrye Bash.",
                 dialog_class_path="wizards.wrye_bash.WryeBashWizard",
             ),
+            WizardTool(
+                id="run_skygen_skyrim",
+                label="SkyGen — Patch Generator",
+                description="Scan your load order for BOS / SkyPatcher patch coverage and generate new patches.",
+                dialog_class_path="wizards.skygen.SkyGenWizard",
+            ),
+            WizardTool(
+                id="run_plugin_audit_skyrim",
+                label="Plugin Audit & Cleanup",
+                description=(
+                    "Scan load order for safe-to-disable plugins, then clean up orphaned "
+                    "SkyGen BOS/SkyPatcher INIs for plugins that must stay enabled."
+                ),
+                dialog_class_path="wizards.plugin_audit.PluginAuditWizard",
+            ),
         ]
 
     @property
@@ -1287,6 +1302,21 @@ class SkyrimVR(Fallout_3):
                 label="Run Wrye Bash",
                 description="Download and run Wrye Bash.",
                 dialog_class_path="wizards.wrye_bash.WryeBashWizard",
+            ),
+            WizardTool(
+                id="run_skygen_skyrimvr",
+                label="SkyGen — Patch Generator",
+                description="Scan your load order for BOS / SkyPatcher patch coverage and generate new patches.",
+                dialog_class_path="wizards.skygen.SkyGenWizard",
+            ),
+            WizardTool(
+                id="run_plugin_audit_skyrimvr",
+                label="Plugin Audit & Cleanup",
+                description=(
+                    "Scan load order for safe-to-disable plugins, then clean up orphaned "
+                    "SkyGen BOS/SkyPatcher INIs for plugins that must stay enabled."
+                ),
+                dialog_class_path="wizards.plugin_audit.PluginAuditWizard",
             ),
         ]
 

--- a/src/Games/Skyrim Special Edition/skyrim_se.py
+++ b/src/Games/Skyrim Special Edition/skyrim_se.py
@@ -267,6 +267,24 @@ class SkyrimSE(Fallout_3):
                 description="Download ParallaxR from Nexus, deploy mods, and process parallax textures.",
                 dialog_class_path="wizards.bendr_parallaxr.ParallaxRWizard",
             ),
+            WizardTool(
+                id="run_skygen_skyrimse",
+                label="SkyGen — Patch Generator",
+                description=(
+                    "Scan your load order for Base Object Swapper / SkyPatcher patch coverage "
+                    "and generate new BOS or SP INI patches."
+                ),
+                dialog_class_path="wizards.skygen.SkyGenWizard",
+            ),
+            WizardTool(
+                id="run_plugin_audit_skyrimse",
+                label="Plugin Audit & Cleanup",
+                description=(
+                    "Scan load order for safe-to-disable plugins, then disable them or clean up "
+                    "orphaned SkyGen BOS/SkyPatcher INIs for plugins that must stay enabled."
+                ),
+                dialog_class_path="wizards.plugin_audit.PluginAuditWizard",
+            ),
         ]
 
     # -----------------------------------------------------------------------

--- a/src/gui/plugin_panel.py
+++ b/src/gui/plugin_panel.py
@@ -3644,7 +3644,6 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
             return
 
         staging_str = str(self._staging_root)
-        # Cache key: sum of mod subfolder mtimes
         try:
             total_mtime = sum(
                 d.stat().st_mtime
@@ -3657,71 +3656,87 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
         if cache_key == self._bos_sp_cache_key:
             return
 
-        result: dict[str, str] = {}
+        all_plugins: set[str] = set()   # all plugin basenames (lowercase) found in staging
+        bos_stems: set[str] = set()     # plugin stems (lowercase) with a _SWAP.ini
+        sp_plugins: set[str] = set()    # plugin names (lowercase) in filterByFormID entries
+
         try:
             for mod_dir in self._staging_root.iterdir():
                 if not mod_dir.is_dir():
                     continue
 
-                # Search roots: top-level and FOMOD Data/ layout
                 search_roots = [mod_dir]
                 data_sub = mod_dir / "Data"
                 if data_sub.is_dir():
                     search_roots.append(data_sub)
 
-                # Collect plugins from both roots
-                plugins_in_mod: list[str] = []
+                # Collect plugin basenames
                 for root in search_roots:
                     try:
                         for f in root.iterdir():
                             if f.is_file() and f.suffix.lower() in {".esp", ".esm", ".esl"}:
-                                plugins_in_mod.append(f.name.lower())
+                                all_plugins.add(f.name.lower())
                     except OSError:
                         pass
 
-                if not plugins_in_mod:
-                    continue
-
-                # BOS: per-plugin stem match (_SWAP.ini, case-insensitive)
-                bos_plugins: set[str] = set()
+                # BOS: any <stem>_SWAP.ini anywhere under the mod
                 for root in search_roots:
                     try:
                         for f in root.rglob("*.ini"):
-                            fn_lower = f.name.lower()
-                            if not fn_lower.endswith("_swap.ini"):
-                                continue
-                            if not f.is_file():
-                                continue
-                            matched_stem = fn_lower[:-len("_swap.ini")]
-                            for pname in plugins_in_mod:
-                                if Path(pname).stem.lower() == matched_stem:
-                                    bos_plugins.add(pname)
+                            if f.is_file() and f.name.lower().endswith("_swap.ini"):
+                                bos_stems.add(f.name.lower()[:-len("_swap.ini")])
                     except OSError:
                         pass
 
-                # SP: SKSE/Plugins/SkyPatcher/ or SkyPatcher2/ directory
-                has_sp = (
-                    (mod_dir / "SKSE" / "Plugins" / "SkyPatcher").is_dir()
-                    or (mod_dir / "SKSE" / "Plugins" / "SkyPatcher2").is_dir()
-                )
-
-                # Tag plugins
-                for pname in plugins_in_mod:
-                    is_bos = pname in bos_plugins
-                    if is_bos and has_sp:
-                        result[pname] = "both"
-                    elif is_bos:
-                        result[pname] = "bos"
-                    elif has_sp:
-                        result[pname] = "sp"
+                # SP: parse filterByFormID lines in SkyPatcher/SkyPatcher2 INIs.
+                # Each entry: filterByFormID = Plugin.esp|FormID
+                # A patch mod targeting another mod's plugin lives here, so scan
+                # all mods — not just the mod that owns the plugin.
+                for sp_dir_name in ("SkyPatcher", "SkyPatcher2"):
+                    sp_dir = mod_dir / "SKSE" / "Plugins" / sp_dir_name
+                    if not sp_dir.is_dir():
+                        continue
+                    try:
+                        for ini in sp_dir.rglob("*.ini"):
+                            if not ini.is_file():
+                                continue
+                            try:
+                                for line in ini.read_text(
+                                    encoding="utf-8", errors="ignore"
+                                ).splitlines():
+                                    s = line.strip()
+                                    if not s or s.startswith(";"):
+                                        continue
+                                    if s.lower().startswith("filterbyformid"):
+                                        eq = s.find("=")
+                                        if eq == -1:
+                                            continue
+                                        val = s[eq + 1:].strip()
+                                        if "|" in val:
+                                            ref = val.split("|")[0].strip().lower()
+                                            if ref.endswith((".esp", ".esm", ".esl")):
+                                                sp_plugins.add(ref)
+                            except (OSError, UnicodeDecodeError):
+                                pass
+                    except OSError:
+                        pass
 
         except OSError:
             pass
 
+        result: dict[str, str] = {}
+        for pname in all_plugins:
+            is_bos = Path(pname).stem.lower() in bos_stems
+            is_sp = pname in sp_plugins
+            if is_bos and is_sp:
+                result[pname] = "both"
+            elif is_bos:
+                result[pname] = "bos"
+            elif is_sp:
+                result[pname] = "sp"
+
         self._bos_sp_plugins = result
         self._bos_sp_cache_key = cache_key
-        # Schedule a redraw on the Tk thread so badges appear without
-        # requiring the user to interact with the panel.
         try:
             self.after(0, self._predraw)
         except Exception:

--- a/src/gui/plugin_panel.py
+++ b/src/gui/plugin_panel.py
@@ -628,6 +628,7 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
         self._pool_ul_dot: list[int] = []
         self._pool_esl_badge: list[int] = []
         self._pool_loot_info: list[int | None] = []
+        self._pool_bos_sp_badge: list[int] = []
         # lowercase plugin name -> full info dict persisted to loot.json:
         # {messages, dirty, requirements, incompatibilities, locations}
         self._loot_info: dict[str, dict] = {}
@@ -644,6 +645,10 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
         # version-mismatch checks are expensive (~450 ms for 1300 plugins).
         # Keyed by (filemap_mtime, plugins_tuple, data_dir_str).
         self._masters_cache_key: tuple | None = None
+        # BOS / SkyPatcher patch detection
+        # plugin_name.lower() -> "bos", "sp", or "both"
+        self._bos_sp_plugins: dict[str, str] = {}
+        self._bos_sp_cache_key: tuple | None = None  # (staging_mtime, staging_str)
         self._userlist_plugins: set[str] = set()
         # Plugins (lowercased names) that participate in a userlist.yaml cycle.
         # Used to paint the userlist dot red instead of white.
@@ -2207,6 +2212,9 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
             ("filter_esl_safe",        "Show only ESL-safe plugins"),
             ("filter_esl_unsafe",      "Show only ESL-unsafe plugins"),
             ("filter_userlist",        "Show only plugins managed by userlist.yaml"),
+            ("filter_bos_sp",          "Show only BOS/SP-patched plugins [B/S badge]"),
+            ("filter_bos_only",        "Show only BOS-patched plugins [B badge]"),
+            ("filter_sp_only",         "Show only SkyPatcher-patched plugins [S badge]"),
         ]
 
         self._pfsp_vars: dict[str, tk.BooleanVar] = {}
@@ -2364,6 +2372,12 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
                                               anchor="center", state="hidden")
             self._pool_loot_info.append(loot_info_id)
 
+            bos_sp_badge = c.create_text(0, -200, text="", anchor="center",
+                                         fill="#c084fc",
+                                         font=(_theme.FONT_FAMILY, _theme.FS11, "bold"),
+                                         state="hidden")
+            self._pool_bos_sp_badge.append(bos_sp_badge)
+
             def _lk_release(e, slot=s):
                 self._on_pool_lock_toggle(slot)
                 return "break"
@@ -2456,6 +2470,17 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
                 if fs.get("filter_esl_unsafe") and name_lower not in self._esl_unsafe_plugins:
                     continue
                 if fs.get("filter_userlist") and name_lower not in self._userlist_plugins:
+                    continue
+                if fs.get("filter_bos_sp") and name_lower not in self._bos_sp_plugins:
+                    continue
+                # Both checked = show any patched plugin (union)
+                _bos_kind = self._bos_sp_plugins.get(name_lower, "")
+                if fs.get("filter_bos_only") and fs.get("filter_sp_only"):
+                    if not _bos_kind:
+                        continue
+                elif fs.get("filter_bos_only") and _bos_kind not in ("bos", "both"):
+                    continue
+                elif fs.get("filter_sp_only") and _bos_kind not in ("sp", "both"):
                     continue
 
             result.append(i)
@@ -3102,6 +3127,8 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
                 is_vanilla = name_lower in self._vanilla_plugins
                 is_locked = bool(self._plugin_locks.get(entry.name, False))
                 has_loot = self._has_loot_tooltip_content(entry.name)
+                bos_sp_kind = self._bos_sp_plugins.get(name_lower, "")
+                has_bos_sp = bool(bos_sp_kind)
 
                 state_key = (
                     "v",
@@ -3121,6 +3148,7 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
                     is_vanilla,
                     is_locked,
                     has_loot,
+                    bos_sp_kind,
                 )
                 if _pool_last_state[s] == state_key and self._pool_data_idx[s] == actual_idx:
                     continue
@@ -3156,7 +3184,7 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
 
                 flags_x0 = self._pcol_x[2]
                 flags_x1 = self._pcol_x[3]
-                active_flags = [f for f in [has_missing, has_late, has_vmm, has_ul, has_esl, has_loot] if f]
+                active_flags = [f for f in [has_missing, has_late, has_vmm, has_ul, has_esl, has_loot, has_bos_sp] if f]
                 n_flags = len(active_flags)
                 # Pack flags tightly with a fixed gap, centered in the column.
                 flag_gap = scaled(20)
@@ -3216,6 +3244,17 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
                     else:
                         c.itemconfigure(loot_info_id, state="hidden")
 
+                bos_sp_badge_id = self._pool_bos_sp_badge[s] if s < len(self._pool_bos_sp_badge) else None
+                if bos_sp_badge_id is not None:
+                    bos_sp_kind = self._bos_sp_plugins.get(name_lower, "")
+                    if bos_sp_kind:
+                        _bos_sp_label = {"bos": "B", "sp": "S", "both": "B+S"}.get(bos_sp_kind, "P")
+                        _bos_sp_color = {"bos": "#60a5fa", "sp": "#fbbf24", "both": "#c084fc"}.get(bos_sp_kind, "#c084fc")
+                        c.coords(bos_sp_badge_id, next(_flag_pos), y_mid)
+                        c.itemconfigure(bos_sp_badge_id, text=_bos_sp_label, fill=_bos_sp_color, state="normal")
+                    else:
+                        c.itemconfigure(bos_sp_badge_id, state="hidden")
+
                 self._pool_data_idx[s] = actual_idx
 
                 if not dragging:
@@ -3267,6 +3306,8 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
                     c.itemconfigure(self._pool_esl_badge[s], state="hidden")
                 if s < len(self._pool_loot_info) and self._pool_loot_info[s] is not None:
                     c.itemconfigure(self._pool_loot_info[s], state="hidden")
+                if s < len(self._pool_bos_sp_badge):
+                    c.itemconfigure(self._pool_bos_sp_badge[s], state="hidden")
                 c.itemconfigure(self._pool_check_rects[s], state="hidden")
                 c.itemconfigure(self._pool_check_marks[s], state="hidden")
                 c.itemconfigure(self._pool_lock_rects[s], state="hidden")
@@ -3578,6 +3619,113 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
             self._version_mismatch_masters = {}
         self._load_esl_flags(plugin_paths)
         self._masters_cache_key = cache_key
+        # BOS/SP scan: run off main thread to keep UI responsive
+        # trigger a redraw via after().
+        import threading as _threading
+        _threading.Thread(
+            target=self._scan_bos_sp_patches, daemon=True
+        ).start()
+
+
+    # ------------------------------------------------------------------
+    # BOS / SkyPatcher patch detection
+    # ------------------------------------------------------------------
+
+    def _scan_bos_sp_patches(self) -> None:
+        """Scan staging mods for BOS/SkyPatcher patches (background thread)."""
+        try:
+            self._do_scan_bos_sp()
+        except Exception as exc:
+            import traceback
+            traceback.print_exc()
+
+    def _do_scan_bos_sp(self) -> None:
+        if self._staging_root is None:
+            return
+
+        staging_str = str(self._staging_root)
+        # Cache key: sum of mod subfolder mtimes
+        try:
+            total_mtime = sum(
+                d.stat().st_mtime
+                for d in self._staging_root.iterdir()
+                if d.is_dir()
+            )
+        except OSError:
+            total_mtime = 0.0
+        cache_key = (total_mtime, staging_str)
+        if cache_key == self._bos_sp_cache_key:
+            return
+
+        result: dict[str, str] = {}
+        try:
+            for mod_dir in self._staging_root.iterdir():
+                if not mod_dir.is_dir():
+                    continue
+
+                # Search roots: top-level and FOMOD Data/ layout
+                search_roots = [mod_dir]
+                data_sub = mod_dir / "Data"
+                if data_sub.is_dir():
+                    search_roots.append(data_sub)
+
+                # Collect plugins from both roots
+                plugins_in_mod: list[str] = []
+                for root in search_roots:
+                    try:
+                        for f in root.iterdir():
+                            if f.is_file() and f.suffix.lower() in {".esp", ".esm", ".esl"}:
+                                plugins_in_mod.append(f.name.lower())
+                    except OSError:
+                        pass
+
+                if not plugins_in_mod:
+                    continue
+
+                # BOS: per-plugin stem match (_SWAP.ini, case-insensitive)
+                bos_plugins: set[str] = set()
+                for root in search_roots:
+                    try:
+                        for f in root.rglob("*.ini"):
+                            fn_lower = f.name.lower()
+                            if not fn_lower.endswith("_swap.ini"):
+                                continue
+                            if not f.is_file():
+                                continue
+                            matched_stem = fn_lower[:-len("_swap.ini")]
+                            for pname in plugins_in_mod:
+                                if Path(pname).stem.lower() == matched_stem:
+                                    bos_plugins.add(pname)
+                    except OSError:
+                        pass
+
+                # SP: SKSE/Plugins/SkyPatcher/ or SkyPatcher2/ directory
+                has_sp = (
+                    (mod_dir / "SKSE" / "Plugins" / "SkyPatcher").is_dir()
+                    or (mod_dir / "SKSE" / "Plugins" / "SkyPatcher2").is_dir()
+                )
+
+                # Tag plugins
+                for pname in plugins_in_mod:
+                    is_bos = pname in bos_plugins
+                    if is_bos and has_sp:
+                        result[pname] = "both"
+                    elif is_bos:
+                        result[pname] = "bos"
+                    elif has_sp:
+                        result[pname] = "sp"
+
+        except OSError:
+            pass
+
+        self._bos_sp_plugins = result
+        self._bos_sp_cache_key = cache_key
+        # Schedule a redraw on the Tk thread so badges appear without
+        # requiring the user to interact with the panel.
+        try:
+            self.after(0, self._predraw)
+        except Exception:
+            pass
 
 
     # ------------------------------------------------------------------
@@ -4046,6 +4194,12 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
                            lambda idxs=toggleable: self._disable_selected_plugins(idxs)))
             plugin_name = self._plugin_entries[toggleable[0]].name
             plugin_idx = toggleable[0]
+            # BOS/SP quick-disable
+            _bos_sp_kind = self._bos_sp_plugins.get(plugin_name.lower(), "")
+            if _bos_sp_kind:
+                _bos_sp_desc = {"bos": "BOS", "sp": "SkyPatcher", "both": "BOS+SkyPatcher"}.get(_bos_sp_kind, "BOS/SP")
+                items.append((f"Disable — {_bos_sp_desc} patch replaces it",
+                               lambda idxs=[plugin_idx]: self._disable_selected_plugins(idxs)))
             # ESL flag toggle — only for .esp/.esm; .esl files are always light
             if _game_supports_esl and not plugin_name.lower().endswith(".esl"):
                 is_esl = plugin_name.lower() in self._esl_flagged_plugins
@@ -4094,6 +4248,12 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
             items.append((f"Disable selected ({count})",
                            lambda idxs=toggleable: self._disable_selected_plugins(idxs)))
             names = [self._plugin_entries[i].name for i in toggleable]
+            # BOS/SP quick-disable for multi-select
+            _bos_sp_idxs = [i for i in toggleable
+                            if self._bos_sp_plugins.get(self._plugin_entries[i].name.lower(), "")]
+            if _bos_sp_idxs:
+                items.append((f"Disable {len(_bos_sp_idxs)} BOS/SP-patched (safe to disable)",
+                               lambda idxs=_bos_sp_idxs: self._disable_selected_plugins(idxs)))
             # ESL flag toggle for multiple plugins — skip pure .esl files
             if _game_supports_esl:
                 esl_eligible_idxs = [

--- a/src/wizards/plugin_audit.py
+++ b/src/wizards/plugin_audit.py
@@ -1,0 +1,1170 @@
+"""
+plugin_audit.py — Plugin Audit & Cleanup wizard.
+
+Scans load order for safe-to-disable plugins and removes orphaned
+SkyGen BOS/SkyPatcher INIs for plugins that must stay enabled.
+
+Safety rules:
+1. A plugin is safe only if ALL dependents are also safe (transitive).
+2. Higher Amethyst priority wins conflicts.
+3. "Disable Selected" writes to plugins.txt directly.
+"""
+
+from __future__ import annotations
+
+import mmap
+import re
+import threading
+import tkinter.messagebox as tkmb
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+
+import customtkinter as ctk
+
+if TYPE_CHECKING:
+    from Games.base_game import BaseGame
+
+from gui.theme import (
+    ACCENT,
+    ACCENT_HOV,
+    BG_DEEP,
+    BG_HEADER,
+    BG_PANEL,
+    FONT_BOLD,
+    FONT_NORMAL,
+    TEXT_DIM,
+    TEXT_MAIN,
+    TEXT_ON_ACCENT,
+)
+# -----------------------------------------------
+# Constants & helpers
+# -----------------------------------------------
+
+BASE_GAME_PLUGINS = {
+    "Skyrim.esm", "Update.esm", "Dawnguard.esm", "HearthFires.esm",
+    "Dragonborn.esm", "ccBGSSSE001-Fish.esm",
+}
+
+# Patch-type labels and colours
+_PATCH_LABELS = {
+    "PRE_PATCHED_BOS":       ("Base Object Swapper", "#5ba8e0"),
+    "PRE_PATCHED_SP":        ("SkyPatcher",          "#e0a85b"),
+    "PRE_PATCHED_SPID":      ("SPID",                "#e0a85b"),
+    "PRE_PATCHED_KID":       ("KID",                 "#e0a85b"),
+    "PRE_PATCHED_DSD":       ("DSD",                 "#e0a85b"),
+    "PRE_PATCHED_OAR":       ("OAR",                 "#e0a85b"),
+    "PRE_PATCHED_SYNTHESIS": ("Synthesis",            "#e0a85b"),
+    "PRE_PATCHED_BASHED":    ("Bashed Patch",         "#8b5cf6"),
+}
+
+SAFE_COLOR   = "#6bc76b"
+UNSAFE_COLOR = "#e06c6c"
+WARN_COLOR   = "#e0c45b"
+
+# Helpers
+
+def _read_active_profile(game: "BaseGame") -> str:
+    active_dir = getattr(game, "_active_profile_dir", None)
+    if active_dir is not None:
+        name = Path(active_dir).name
+        if name:
+            return name
+    try:
+        last = game.get_last_active_profile()
+        if last and last != "default":
+            candidate = game.get_profile_root() / "profiles" / last
+            if candidate.is_dir():
+                return last
+    except Exception:
+        pass
+    try:
+        profiles_root = game.get_profile_root() / "profiles"
+        if profiles_root.is_dir():
+            candidates = sorted(
+                d for d in profiles_root.iterdir()
+                if d.is_dir() and d.name != "default" and (d / "loadorder.txt").is_file()
+            )
+            if candidates:
+                return candidates[0].name
+    except Exception:
+        pass
+    return "default"
+
+
+def _profile_dir(game: "BaseGame", profile: str) -> Path:
+    return game.get_profile_root() / "profiles" / profile
+
+
+def _read_loadorder(game: "BaseGame", profile: str) -> List[str]:
+    pdir = _profile_dir(game, profile)
+    lo_path = pdir / "loadorder.txt"
+    pl_path = pdir / "plugins.txt"
+
+    full_order: List[str] = []
+    if lo_path.is_file():
+        for line in lo_path.read_text(encoding="utf-8").splitlines():
+            line = line.split("#")[0].strip()
+            if line:
+                full_order.append(line)
+
+    active_set: Set[str] = set()
+    if pl_path.is_file():
+        for line in pl_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line.startswith("*"):
+                active_set.add(line[1:].strip())
+            elif not line.startswith("#") and line:
+                active_set.add(line)
+
+    if not full_order:
+        return list(active_set)
+    return [p for p in full_order if p in BASE_GAME_PLUGINS or p in active_set]
+
+
+def _read_modlist_priorities(game: "BaseGame", profile: str) -> Dict[str, int]:
+    """{mod_name: priority}. Higher = wins conflicts. modlist.txt line 0 = highest."""
+    pdir = _profile_dir(game, profile)
+    ml_path = pdir / "modlist.txt"
+    if not ml_path.is_file():
+        # Fall back to shared modlist
+        ml_path = game.get_profile_root() / "profiles" / profile / "modlist.txt"
+    if not ml_path.is_file():
+        return {}
+
+    real_mods: List[str] = []
+    for line in ml_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line[0] not in ("+", "-", "*"):
+            continue
+        name = line[1:]
+        if name.endswith("_separator"):
+            continue
+        real_mods.append(name)
+
+    total = len(real_mods)
+    return {name: (total - 1 - i) for i, name in enumerate(real_mods)}
+
+
+_plugin_file_cache: Dict[str, Optional[Path]] = {}
+
+def _find_plugin_file(plugin_name: str, mods_path: Path,
+                      game: "BaseGame") -> Optional[Path]:
+    """Locate plugin file on disk. Result cached per run."""
+    key = f"{mods_path}|{plugin_name}"
+    if key in _plugin_file_cache:
+        return _plugin_file_cache[key]
+    result: Optional[Path] = None
+    # 1. Inside staging mods
+    if mods_path and mods_path.is_dir():
+        for mod_dir in mods_path.iterdir():
+            if not mod_dir.is_dir():
+                continue
+            for candidate in (mod_dir / plugin_name, mod_dir / "Data" / plugin_name):
+                if candidate.is_file():
+                    result = candidate
+                    break
+            if result:
+                break
+    # 2. Vanilla data dir
+    if result is None:
+        try:
+            data_path = game.get_game_folder() / "Data" / plugin_name
+            if data_path.is_file():
+                result = data_path
+        except Exception:
+            pass
+    _plugin_file_cache[key] = result
+    return result
+
+
+def _find_mod_folder(plugin_path: Path, mods_path: Path) -> Optional[Path]:
+    try:
+        rel = plugin_path.relative_to(mods_path)
+        return mods_path / rel.parts[0]
+    except ValueError:
+        return None
+
+
+def _parse_header(path: Path) -> Tuple[str, List[str]]:
+    try:
+        with open(path, "rb") as f:
+            data = f.read(8192)
+        if len(data) < 24 or data[:4] != b"TES4":
+            return "Unknown", []
+        tes4_size = int.from_bytes(data[4:8], "little")
+        offset, end = 24, min(24 + tes4_size, len(data))
+        author, masters = "Unknown", []
+        while offset < end - 6:
+            st = data[offset:offset + 4]
+            ss = int.from_bytes(data[offset + 4:offset + 6], "little")
+            offset += 6
+            if offset + ss > len(data):
+                break
+            chunk = data[offset:offset + ss]
+            if chunk and chunk[-1] == 0:
+                chunk = chunk[:-1]
+            text = chunk.decode("utf-8", errors="ignore").strip()
+            if st == b"CNAM":
+                author = text or "Unknown"
+            elif st == b"MAST" and text:
+                masters.append(text)
+            offset += ss
+        return author, masters
+    except Exception:
+        return "Unknown", []
+
+
+def _plugin_has_new_records(path: Path) -> bool:
+    """True if plugin adds FormIDs not owned by any master → cannot disable even with patch."""
+    try:
+        with open(path, "rb") as f:
+            with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as data:
+                return _scan_data_for_new_records(data)
+    except OSError:
+        return True
+
+
+def _scan_data_for_new_records(data: bytes) -> bool:
+    """Core scan — accepts bytes, mmap, or any buffer object."""
+
+    if len(data) < 28 or data[:4] != b"TES4":
+        return True
+
+    tes4_size = int.from_bytes(data[4:8], "little", signed=False)
+    if tes4_size < 4:
+        return True
+
+    # ESL flag (bit 11) at offset 8–11
+    flags = int.from_bytes(data[8:12], "little", signed=False)
+    is_esl = bool(flags & 0x00000800)
+
+    # Count masters from MAST subrecords
+    num_masters = 0
+    offset = 24
+    tes4_end = min(24 + tes4_size, len(data))
+    while offset <= tes4_end - 6:
+        st = data[offset:offset + 4]
+        ss = int.from_bytes(data[offset + 4:offset + 6], "little", signed=False)
+        offset += 6
+        if offset + ss > len(data):
+            break
+        if st == b"MAST":
+            num_masters += 1
+        offset += ss
+
+    master_set: Set[int] = set(range(num_masters))
+
+    # Recursively scan GRUP tree for record FormIDs
+    def _scan(pos: int, end: int) -> int:
+        count = 0
+        while pos < end - 20:
+            if data[pos:pos + 4] == b"GRUP":
+                gs = int.from_bytes(data[pos + 4:pos + 8], "little", signed=False)
+                if gs < 20 or pos + gs > end:
+                    pos += 1
+                    continue
+                count += _scan(pos + 20, pos + gs)
+                pos += gs
+                continue
+
+            sig = data[pos:pos + 4]
+            if not all(65 <= b <= 90 for b in sig):
+                pos += 1
+                continue
+            if sig == b"TES4":
+                ds = int.from_bytes(data[pos + 4:pos + 8], "little", signed=False)
+                pos += 24 + ds
+                continue
+
+            ds = int.from_bytes(data[pos + 4:pos + 8], "little", signed=False)
+            if ds > 100_000_000:
+                pos += 1
+                continue
+
+            formid = int.from_bytes(data[pos + 12:pos + 16], "little", signed=False)
+            src = (formid >> 24) & 0xFF
+
+            if is_esl:
+            # ESL-compacted new records have FormID < 0x1000.
+            # Skyrim.esm overrides are >> 0x1000, so this distinguishes them.
+                if src == 0x00 and 0 < formid < 0x1000:
+                    count += 1
+                elif src not in master_set:
+                    count += 1
+            else:
+                if src not in master_set:
+                    count += 1
+
+            pos += 24 + ds
+            while pos & 3:
+                pos += 1
+
+        return count
+
+    new_count = _scan(24 + tes4_size, len(data))
+    return new_count > 0
+
+
+def _build_patch_index(mods_path: Path) -> Tuple[Set[str], Set[str]]:
+    """Return (bos_patched, sp_patched) — lower-case plugin name sets."""
+    bos_patched: Set[str] = set()
+    sp_patched:  Set[str] = set()
+    if not mods_path or not mods_path.is_dir():
+        return bos_patched, sp_patched
+    _for_re = re.compile(r"for\s+([^\s\r\n]+\.es[pml])", re.I)
+
+    try:
+        for mod_dir in mods_path.iterdir():
+            if not mod_dir.is_dir():
+                continue
+            bos_dir = mod_dir / "SKSE" / "Plugins" / "Data" / "Base Object Swapper"
+            if bos_dir.is_dir():
+                for ini in bos_dir.rglob("*.ini"):
+                    try:
+                        header = ini.read_text(encoding="utf-8", errors="ignore")[:512]
+                    except OSError:
+                        continue
+                    m = _for_re.search(header)
+                    if m:
+                        bos_patched.add(m.group(1).lower())
+                    else:
+                        stem = ini.stem.lower()
+                        for suffix in ("_skygen_swap", "_swap"):
+                            if stem.endswith(suffix):
+                                stem = stem[:-len(suffix)]
+                                break
+                        for ext in (".esp", ".esm", ".esl"):
+                            bos_patched.add(stem + ext)
+            try:
+                for ini in mod_dir.rglob("*_swap.ini"):
+                    stem = ini.stem.lower()
+                    if stem.endswith("_swap"):
+                        stem = stem[:-5]
+                    for ext in (".esp", ".esm", ".esl"):
+                        bos_patched.add(stem + ext)
+            except OSError:
+                pass
+            for sp_name in ("SkyPatcher", "SkyPatcher2"):
+                sp_dir = mod_dir / "SKSE" / "Plugins" / sp_name
+                if sp_dir.is_dir():
+                    for ini in sp_dir.rglob("*.ini"):
+                        try:
+                            header = ini.read_text(encoding="utf-8", errors="ignore")[:512]
+                        except OSError:
+                            continue
+                        m = _for_re.search(header)
+                        if m:
+                            sp_patched.add(m.group(1).lower())
+                        else:
+                            stem = ini.stem.lower()
+                            stem = re.sub(r"^[0-9a-f]+-", "", stem)
+                            if stem.endswith("_skygen"):
+                                stem = stem[:-7]
+                            for ext in (".esp", ".esm", ".esl"):
+                                sp_patched.add(stem + ext)
+                    break
+            # SPID / KID / DSD — scan relevant extensions only
+            try:
+                for pattern in ("*.ini", "*.json", "*.yaml", "*.yml"):
+                    for f in mod_dir.rglob(pattern):
+                        if not f.is_file():
+                            continue
+                        nl = f.name.lower()
+                        stem = f.stem.lower()
+                        base_stem = stem
+                        for suffix in ("_distr", "_kid", "_dsd"):
+                            if stem.endswith(suffix):
+                                base_stem = stem[:-len(suffix)]
+                                break
+                        if nl.endswith("_distr.ini"):
+                            sp_patched.add(base_stem + ".esp")
+                            sp_patched.add(base_stem + ".esm")
+                            sp_patched.add(base_stem + ".esl")
+                        elif nl.endswith("_kid.ini"):
+                            sp_patched.add(base_stem + ".esp")
+                            sp_patched.add(base_stem + ".esm")
+                            sp_patched.add(base_stem + ".esl")
+                        elif nl.endswith("_dsd.json") or nl.endswith("_dsd.yaml"):
+                            sp_patched.add(base_stem + ".esp")
+                            sp_patched.add(base_stem + ".esm")
+                            sp_patched.add(base_stem + ".esl")
+            except OSError:
+                pass
+    except OSError:
+        pass
+    return bos_patched, sp_patched
+
+
+def _get_priority_for_plugin(plugin_name: str, mods_path: Path,
+                              priorities: Dict[str, int]) -> int:
+    """Amethyst mod priority for the plugin's owner. -1 if not found."""
+    if not mods_path or not mods_path.is_dir():
+        return -1
+    for mod_dir in mods_path.iterdir():
+        if not mod_dir.is_dir():
+            continue
+        for sub in (mod_dir, mod_dir / "Data"):
+            if (sub / plugin_name).is_file():
+                return priorities.get(mod_dir.name, -1)
+    return -1
+
+
+def _has_skygen_ini(plugin_name: str, mods_path: Optional[Path]) -> bool:
+    """True if a SkyGen INI for this plugin exists in the SkyGen output directories."""
+    if not mods_path or not mods_path.is_dir():
+        return False
+    stem = Path(plugin_name).stem.lower()
+    base = mods_path
+
+    # BOS: SkyGen BOS/SKSE/Plugins/Data/Base Object Swapper/{stem}_SkyGen_SWAP.ini
+    ini = base / "SkyGen BOS" / "SKSE" / "Plugins" / "Data" / "Base Object Swapper" / f"{stem}_SkyGen_SWAP.ini"
+    if ini.is_file():
+        return True
+
+    # BOS (legacy naming): {stem}_SkyGen_SWAP.ini anywhere in mod
+    bos_mod = base / "SkyGen BOS"
+    if bos_mod.is_dir():
+        for f in bos_mod.rglob("*.ini"):
+            fn = f.name.lower()
+            if fn == f"{stem}_skygen_swap.ini" or fn.endswith(f"{stem}_skygen_swap.ini"):
+                return True
+
+    # SkyPatcher: uses load-order prefix, so we check within the SP dir
+    for sp_dir_name in ("SkyPatcher", "SkyPatcher2"):
+        sp_dir = base / "SkyGen SkyPatcher" / "SKSE" / "Plugins" / sp_dir_name
+        if not sp_dir.is_dir():
+            continue
+        for f in sp_dir.rglob("*.ini"):
+            fn_lower = f.stem.lower()
+            # Strip load-order prefix (e.g. "03-") then check for _skygen
+            cleaned = re.sub(r"^[0-9a-f]+-", "", fn_lower)
+            if cleaned == f"{stem}_skygen" or cleaned == stem:
+                return True
+        break
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AuditEntry:
+    plugin_name:    str
+    masters:        List[str]
+    patch_scents:   Set[str]           # PRE_PATCHED_* flags
+    mod_name:       str                # owning mod folder name
+    priority:       int                # Amethyst priority (higher = wins)
+    dependents:     List[str] = field(default_factory=list)
+    transitively_safe: bool = False
+    has_new_records: bool = False      # plugin adds its own FormIDs
+    patch_is_skygen: bool = False      # patch INI resides in SkyGen output dir
+
+    @property
+    def is_patched(self) -> bool:
+        return bool(self.patch_scents)
+
+    @property
+    def can_disable(self) -> bool:
+        if self.has_new_records:
+            return False
+        return self.is_patched and (not self.dependents or self.transitively_safe)
+
+    @property
+    def primary_patch_label(self) -> Tuple[str, str]:
+        """(label, colour) for dominant patch type."""
+        for key in ("PRE_PATCHED_BOS", "PRE_PATCHED_SP", "PRE_PATCHED_SPID",
+                    "PRE_PATCHED_KID", "PRE_PATCHED_DSD", "PRE_PATCHED_OAR",
+                    "PRE_PATCHED_SYNTHESIS"):
+            if key in self.patch_scents:
+                return _PATCH_LABELS[key]
+        return ("Unknown", TEXT_DIM)
+
+    @property
+    def unsafe_reason(self) -> str:
+        parts: List[str] = []
+        if self.dependents and not self.transitively_safe:
+            names = ", ".join(self.dependents[:4])
+            extra = f" (+{len(self.dependents)-4} more)" if len(self.dependents) > 4 else ""
+            parts.append(f"Required by: {names}{extra}")
+        if self.has_new_records:
+            parts.append("Adds new records (can't be disabled)")
+        return "; ".join(parts)
+
+
+# Wizard
+
+class PluginAuditWizard(ctk.CTkFrame):
+    """Standalone Plugin Audit & Cleanup wizard."""
+
+    def __init__(
+        self,
+        parent,
+        game: "BaseGame",
+        log_fn=None,
+        *,
+        on_close=None,
+        **_kwargs,
+    ):
+        super().__init__(parent, fg_color=BG_DEEP, corner_radius=0)
+        self._game      = game
+        self._log_fn    = log_fn or (lambda msg: None)
+        self._on_close  = on_close or (lambda: None)
+        self._entries: Dict[str, AuditEntry] = {}
+        self._scan_done = False
+
+        self._build_header()
+        self._body = ctk.CTkFrame(self, fg_color="transparent")
+        self._body.pack(fill="both", expand=True, padx=12, pady=(0, 12))
+
+        self._show_scan_step()
+
+    # ------------------------------------------------------------------
+    # Header
+    # ------------------------------------------------------------------
+
+    def _build_header(self):
+        hdr = ctk.CTkFrame(self, fg_color=BG_HEADER, corner_radius=0)
+        hdr.pack(fill="x")
+        ctk.CTkLabel(
+            hdr,
+            text=f"Plugin Audit & Cleanup \u2014 {self._game.name}",
+            font=FONT_BOLD, text_color=TEXT_MAIN,
+        ).pack(side="left", padx=12, pady=8)
+        ctk.CTkButton(
+            hdr, text="\u2715", width=32, height=32, font=FONT_BOLD,
+            fg_color="transparent", hover_color=BG_PANEL, text_color=TEXT_MAIN,
+            command=self._on_close,
+        ).pack(side="right", padx=4, pady=4)
+
+    # ------------------------------------------------------------------
+    # Step — Scan
+    # ------------------------------------------------------------------
+
+    def _clear_body(self):
+        for w in self._body.winfo_children():
+            w.destroy()
+
+    def _show_scan_step(self):
+        self._clear_body()
+
+        ctk.CTkLabel(
+            self._body,
+            text="Scan Load Order",
+            font=FONT_BOLD, text_color=TEXT_MAIN,
+        ).pack(pady=(8, 4))
+
+        ctk.CTkLabel(
+            self._body,
+            text=(
+                "Scans your active load order and identifies plugins that are safe "
+                "to disable because a patch already replicates their function."
+                "\n\nTakes into account:"
+                "\n  \u2022 BOS, SkyPatcher, SPID, KID, DSD, OAR, Synthesis patches"
+                "\n  \u2022 Master dependencies (transitive resolution)"
+                "\n  \u2022 Amethyst mod priority (higher priority wins conflicts)"
+                "\n  \u2022 New record detection (plugins that add their own FormIDs"
+                "\n    cannot be disabled even with a patch)"
+                "\n  \u2022 Orphaned INI cleanup — removes BOS/SkyPatcher INIs for"
+                "\n    plugins that cannot be disabled"
+            ),
+            font=FONT_NORMAL, text_color=TEXT_DIM, justify="left", wraplength=380,
+        ).pack(pady=(0, 12), fill="x")
+
+        self._log_var = ctk.StringVar(value="Ready.")
+        ctk.CTkLabel(
+            self._body, textvariable=self._log_var,
+            font=FONT_NORMAL, text_color=TEXT_DIM, wraplength=380,
+        ).pack(pady=(0, 6))
+
+        self._progress = ctk.CTkProgressBar(self._body)
+        self._progress.pack(fill="x", padx=20, pady=(0, 12))
+        self._progress.set(0)
+
+        ctk.CTkButton(
+            self._body,
+            text="Start Scan",
+            font=FONT_BOLD, fg_color=ACCENT, hover_color=ACCENT_HOV,
+            text_color=TEXT_ON_ACCENT, width=160, height=40,
+            command=self._start_scan,
+        ).pack()
+
+    def _log(self, msg: str):
+        self._log_fn(msg)
+        self.after(0, lambda m=msg: self._log_var.set(m))
+
+    def _start_scan(self):
+        for w in self._body.winfo_children():
+            try:
+                w.configure(state="disabled")
+            except Exception:
+                pass
+        threading.Thread(target=self._do_scan, daemon=True).start()
+
+    def _do_scan(self):
+        try:
+            game    = self._game
+            profile = _read_active_profile(game)
+            self._log(f"Active profile: '{profile}'")
+
+            lo = _read_loadorder(game, profile)
+            if not lo:
+                self.after(0, lambda: self._log_var.set("No active plugins found."))
+                return
+
+            try:
+                mods_path = game.get_effective_mod_staging_path()
+            except Exception:
+                mods_path = game.get_mod_staging_path()
+
+            self._log("Reading mod priorities…")
+            priorities = _read_modlist_priorities(game, profile)
+
+            # Pre-build plugin→path index in one pass so per-plugin lookups are O(1)
+            self._log("Indexing plugin files…")
+            _plugin_file_cache.clear()
+            if mods_path and mods_path.is_dir():
+                for mod_dir in mods_path.iterdir():
+                    if not mod_dir.is_dir():
+                        continue
+                    for candidate in mod_dir.iterdir():
+                        if candidate.is_file() and candidate.suffix.lower() in (".esp", ".esm", ".esl"):
+                            key = f"{mods_path}|{candidate.name}"
+                            if key not in _plugin_file_cache:
+                                _plugin_file_cache[key] = candidate
+                    data_sub = mod_dir / "Data"
+                    if data_sub.is_dir():
+                        for candidate in data_sub.iterdir():
+                            if candidate.is_file() and candidate.suffix.lower() in (".esp", ".esm", ".esl"):
+                                key = f"{mods_path}|{candidate.name}"
+                                if key not in _plugin_file_cache:
+                                    _plugin_file_cache[key] = candidate
+
+            self._log("Building cross-mod patch index\u2026")
+            bos_idx, sp_idx = _build_patch_index(mods_path)
+            self._log(f"Patch index: {len(bos_idx)} BOS, {len(sp_idx)} SP/other targets")
+
+            total   = len(lo)
+            entries: Dict[str, AuditEntry] = {}
+
+            for i, plugin_name in enumerate(lo):
+                if i % 10 == 0 or i == total - 1:
+                    prog = (i + 1) / total
+                    self.after(0, lambda p=prog: self._progress.set(p))
+
+                if i % 20 == 0 or i == total - 1:
+                    self._log(f"Scanning {i+1}/{total}: {plugin_name}")
+
+                plugin_path = _find_plugin_file(plugin_name, mods_path, game)
+                if plugin_path is None:
+                    continue
+
+                _, masters = _parse_header(plugin_path)
+                mod_folder  = _find_mod_folder(plugin_path, mods_path)
+                mod_name    = mod_folder.name if mod_folder else ""
+                priority    = priorities.get(mod_name, -1)
+
+                has_new = _plugin_has_new_records(plugin_path)
+
+                scents: Set[str] = set()
+                pkey = plugin_name.lower()
+                if pkey in bos_idx:
+                    scents.add("PRE_PATCHED_BOS")
+                if pkey in sp_idx:
+                    scents.add("PRE_PATCHED_SP")
+
+                # Synthesis
+                if plugin_name.lower() in ("synthesis.esp", "synthesis.esm"):
+                    scents.add("PRE_PATCHED_SYNTHESIS")
+
+                # OAR — mod folder has OpenAnimationReplacer dir
+                if mod_folder:
+                    oar_dir = mod_folder / "meshes" / "animationdatasinglefile"
+                    oar_dir2 = mod_folder / "SKSE" / "Plugins" / "OpenAnimationReplacer"
+                    if oar_dir.is_dir() or oar_dir2.is_dir():
+                        scents.add("PRE_PATCHED_OAR")
+
+                entries[plugin_name] = AuditEntry(
+                    plugin_name=plugin_name,
+                    masters=masters,
+                    patch_scents=scents,
+                    mod_name=mod_name,
+                    priority=priority,
+                    has_new_records=has_new,
+                    patch_is_skygen=_has_skygen_ini(plugin_name, mods_path),
+                )
+
+            # --- Bashed Patch coverage ---
+            # Any plugin listed as a master of "Bashed Patch, *.esp" has its
+            # changes merged and is therefore patched (safe to disable).
+            _bp_masters: Set[str] = set()
+            for pname, entry in entries.items():
+                if pname.lower().startswith("bashed patch,"):
+                    for master in entry.masters:
+                        ml = master.lower()
+                        if ml not in BASE_GAME_PLUGINS:
+                            _bp_masters.add(ml)
+            if _bp_masters:
+                for pname, entry in entries.items():
+                    if pname.lower() in _bp_masters:
+                        entry.patch_scents.add("PRE_PATCHED_BASHED")
+
+            # Build reverse dependency map
+            master_to_deps: Dict[str, List[str]] = {}
+            for pname, entry in entries.items():
+                for master in entry.masters:
+                    master_to_deps.setdefault(master.lower(), []).append(pname)
+            for pname, entry in entries.items():
+                entry.dependents = master_to_deps.get(pname.lower(), [])
+
+            # Transitive safe-set resolution
+            def _is_patched(e: AuditEntry) -> bool:
+                return e.is_patched
+
+            safe_set: Set[str] = set()
+            changed = True
+            while changed:
+                changed = False
+                for pname, entry in entries.items():
+                    if pname in safe_set:
+                        continue
+                    if not _is_patched(entry):
+                        continue
+                    all_deps_safe = all(
+                        dep in safe_set or dep not in entries
+                        for dep in entry.dependents
+                    )
+                    if all_deps_safe:
+                        safe_set.add(pname)
+                        changed = True
+
+            for pname, entry in entries.items():
+                if pname in safe_set and entry.dependents:
+                    entry.transitively_safe = True
+                    entry.dependents = []
+
+            self._entries = entries
+            self._scan_done = True
+            self.after(0, self._show_audit_step)
+
+        except Exception as exc:
+            self.after(0, lambda e=exc: self._log_var.set(f"Error: {e}"))
+
+    # ------------------------------------------------------------------
+    # Step — Audit
+    # ------------------------------------------------------------------
+
+    def _show_audit_step(self):
+        self._clear_body()
+
+        entries = self._entries
+
+        safe             = {n: e for n, e in entries.items() if e.can_disable}
+        blocked_by_new   = {
+            n: e for n, e in entries.items()
+            if not e.can_disable and e.is_patched and e.has_new_records
+        }
+        blocked_by_deps  = {
+            n: e for n, e in entries.items()
+            if not e.can_disable and e.is_patched and not e.has_new_records and e.dependents
+        }
+
+        # Header counts
+        parts = [f"Audit complete — {len(entries)} plugins scanned, {len(safe)} safe to disable"]
+        if blocked_by_new:
+            parts.append(f"{len(blocked_by_new)} blocked (new records)")
+        if blocked_by_deps:
+            parts.append(f"{len(blocked_by_deps)} blocked (dependents)")
+        ctk.CTkLabel(
+            self._body,
+            text=", ".join(parts),
+            font=FONT_BOLD, text_color=TEXT_MAIN,
+        ).pack(pady=(8, 4))
+
+        if not safe and not blocked_by_new and not blocked_by_deps:
+            ctk.CTkLabel(
+                self._body,
+                text=(
+                    "No disableable plugins detected.\n\n"
+                    "None of your active plugins have a BOS, SkyPatcher, SPID, KID, "
+                    "DSD, or OAR patch that replaces their function."
+                ),
+                font=FONT_NORMAL, text_color=TEXT_DIM, justify="left", wraplength=380,
+            ).pack(pady=20)
+        else:
+            # Scrollable list
+            scroll = ctk.CTkScrollableFrame(
+                self._body, fg_color=BG_PANEL,
+            )
+            scroll.pack(fill="both", expand=True, pady=(4, 8))
+
+            # Header row
+            hdr = ctk.CTkFrame(scroll, fg_color=BG_HEADER)
+            hdr.pack(fill="x", pady=(0, 4))
+            for col, (label, w) in enumerate([
+                ("",         24),   # checkbox column
+                ("Plugin",   210),
+                ("Patch",    140),
+                ("Priority", 70),
+                ("Status",   220),
+            ]):
+                ctk.CTkLabel(hdr, text=label, font=FONT_BOLD, text_color=TEXT_MAIN,
+                             width=w, anchor="w").grid(row=0, column=col, padx=6, pady=4)
+
+            self._check_vars: Dict[str, ctk.BooleanVar] = {}
+
+            # Safe entries first
+            for plugin_name, entry in sorted(safe.items(),
+                                             key=lambda kv: -kv[1].priority):
+                self._add_audit_row(scroll, plugin_name, entry, selectable=True)
+
+            # Blocked by new records
+            if blocked_by_new:
+                sep = ctk.CTkFrame(scroll, fg_color=WARN_COLOR, height=1)
+                sep.pack(fill="x", pady=(8, 2))
+                ctk.CTkLabel(
+                    scroll,
+                    text="\u26a0  Patched but adds new records—cannot disable (records won't exist without ESP)",
+                    font=FONT_BOLD, text_color=WARN_COLOR,
+                ).pack(anchor="w", padx=8, pady=(0, 4))
+                for plugin_name, entry in sorted(blocked_by_new.items(),
+                                                 key=lambda kv: -kv[1].priority):
+                    self._add_audit_row(scroll, plugin_name, entry, selectable=False)
+
+            # Blocked by dependents
+            if blocked_by_deps:
+                sep = ctk.CTkFrame(scroll, fg_color=UNSAFE_COLOR, height=1)
+                sep.pack(fill="x", pady=(8, 2))
+                ctk.CTkLabel(
+                    scroll,
+                    text="\u26a0  Patched but blocked—other plugins depend on these as masters",
+                    font=FONT_BOLD, text_color=UNSAFE_COLOR,
+                ).pack(anchor="w", padx=8, pady=(0, 4))
+                for plugin_name, entry in sorted(blocked_by_deps.items(),
+                                                 key=lambda kv: -kv[1].priority):
+                    self._add_audit_row(scroll, plugin_name, entry, selectable=False)
+
+        # Bottom buttons
+        btn_row = ctk.CTkFrame(self._body, fg_color="transparent")
+        btn_row.pack(side="bottom", pady=(8, 0))
+
+        ctk.CTkButton(
+            btn_row, text="\u2190 Re-Scan", width=110, height=36,
+            font=FONT_BOLD, fg_color=BG_HEADER, hover_color="#3d3d3d",
+            text_color=TEXT_MAIN, command=self._show_scan_step,
+        ).pack(side="left", padx=(0, 8))
+
+        if safe:
+            ctk.CTkButton(
+                btn_row,
+                text="Select All Safe",
+                width=130, height=36,
+                font=FONT_BOLD, fg_color=BG_HEADER, hover_color="#3d3d3d",
+                text_color=TEXT_MAIN,
+                command=self._select_all,
+            ).pack(side="left", padx=(0, 8))
+
+            ctk.CTkButton(
+                btn_row,
+                text="Disable Selected",
+                width=150, height=36,
+                font=FONT_BOLD, fg_color=ACCENT, hover_color=ACCENT_HOV,
+                text_color=TEXT_ON_ACCENT,
+                command=self._disable_selected,
+            ).pack(side="left")
+
+        # Cleanup orphaned INIs — show whenever any patched plugin can't be disabled
+        any_blocked = bool(blocked_by_new or blocked_by_deps)
+        if any_blocked:
+            ctk.CTkButton(
+                btn_row,
+                text=f"Clean Orphaned INIs",
+                width=160, height=36,
+                font=FONT_BOLD, fg_color=BG_HEADER, hover_color="#3d3d3d",
+                text_color=TEXT_MAIN,
+                command=self._cleanup_orphaned_inis,
+            ).pack(side="right", padx=(8, 0))
+
+    def _add_audit_row(self, parent, plugin_name: str, entry: AuditEntry,
+                       selectable: bool):
+        row = ctk.CTkFrame(parent, fg_color="transparent")
+        row.pack(fill="x", pady=1)
+
+        # Checkbox
+        if selectable:
+            var = ctk.BooleanVar(value=False)
+            self._check_vars[plugin_name] = var
+            ctk.CTkCheckBox(row, text="", variable=var, width=24,
+                            checkbox_width=16, checkbox_height=16,
+                            ).grid(row=0, column=0, padx=6)
+        else:
+            ctk.CTkLabel(row, text="", width=24).grid(row=0, column=0, padx=6)
+
+        # Plugin name
+        ctk.CTkLabel(row, text=plugin_name, font=FONT_NORMAL,
+                     text_color=TEXT_MAIN, width=210, anchor="w",
+                     ).grid(row=0, column=1, padx=6)
+
+        # Patch type
+        label, color = entry.primary_patch_label
+        # If multiple patches apply, append "+"
+        n_patches = len(entry.patch_scents)
+        if n_patches > 1:
+            label += f" +{n_patches - 1}"
+        ctk.CTkLabel(row, text=label, font=FONT_BOLD,
+                     text_color=color, width=140, anchor="w",
+                     ).grid(row=0, column=2, padx=6)
+
+        # Priority
+        prio_text = str(entry.priority) if entry.priority >= 0 else "—"
+        ctk.CTkLabel(row, text=prio_text, font=FONT_NORMAL,
+                     text_color=TEXT_DIM, width=70, anchor="center",
+                     ).grid(row=0, column=3, padx=6)
+
+        # Status
+        if selectable:
+            if entry.transitively_safe:
+                status_text  = "\u2713 Safe (deps also patched)"
+                status_color = SAFE_COLOR
+            else:
+                status_text  = "\u2713 Safe to disable"
+                status_color = SAFE_COLOR
+        else:
+            reason = entry.unsafe_reason
+            if entry.has_new_records:
+                status_text  = "\u26a0 New records"
+                status_color = WARN_COLOR
+            elif entry.dependents:
+                status_text  = "\u26a0 Blocked (deps)"
+                status_color = UNSAFE_COLOR
+            else:
+                status_text  = reason or "\u26a0 Blocked"
+                status_color = UNSAFE_COLOR
+            # Append origin note if not already clear from context
+            if entry.is_patched:
+                if entry.patch_is_skygen:
+                    status_text += "  INI\u2192SkyGen"
+                else:
+                    status_text += "  INI\u2192mod"
+        ctk.CTkLabel(row, text=status_text, font=FONT_NORMAL,
+                     text_color=status_color, width=220, anchor="w",
+                     ).grid(row=0, column=4, padx=6)
+
+    def _select_all(self):
+        for var in self._check_vars.values():
+            var.set(True)
+
+    def _disable_selected(self):
+        selected = [name for name, var in self._check_vars.items() if var.get()]
+        if not selected:
+            return
+
+        # Confirmation dialog
+        ok = tkmb.askyesno(
+            title="Disable Selected Plugins",
+            message=(
+                f"Disable {len(selected)} plugin(s)?\n\n"
+                + "\n".join(f"  \u2022 {n}" for n in selected[:5])
+                + ("\n  \u2022 ..." if len(selected) > 5 else "")
+                + "\n\nThe patches for these plugins will still apply at runtime."
+            ),
+            icon="warning",
+        )
+        if not ok:
+            return
+
+        game    = self._game
+        profile = _read_active_profile(game)
+        pdir    = _profile_dir(game, profile)
+        plugins_path = pdir / "plugins.txt"
+        lo_path      = pdir / "loadorder.txt"
+
+        if not plugins_path.is_file():
+            self._log_var.set("plugins.txt not found — cannot disable.")
+            return
+
+        # Read current plugins.txt
+        lines = plugins_path.read_text(encoding="utf-8").splitlines()
+        selected_lower = {n.lower() for n in selected}
+
+        new_lines = []
+        disabled_count = 0
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("*"):
+                name = stripped[1:]
+                if name.lower() in selected_lower:
+                    new_lines.append(name)   # remove * to disable
+                    disabled_count += 1
+                    continue
+            new_lines.append(line)
+
+        plugins_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+        # Trigger plugin panel reload — same pattern as pgpatcher/_on_done
+        try:
+            topbar = self.winfo_toplevel()._topbar
+        except Exception:
+            topbar = None
+
+        self._on_close()
+
+        if topbar is not None:
+            try:
+                topbar.after(0, topbar._reload_mod_panel)
+            except Exception:
+                pass
+
+    def _cleanup_orphaned_inis(self):
+        """Delete SkyGen INIs for plugins that can't be disabled."""
+        try:
+            mods_path = self._game.get_effective_mod_staging_path()
+        except Exception:
+            mods_path = self._game.get_mod_staging_path()
+        if not mods_path or not mods_path.is_dir():
+            self._log("Cannot find mod staging path \u2014 aborting cleanup.")
+            return
+
+        # Collect target plugin names (lowered) — all patched plugins that
+        # *cannot* be disabled, regardless of *why* (new records OR dependents).
+        targets: Set[str] = set()
+        for pname, entry in self._entries.items():
+            if not entry.can_disable and entry.is_patched:
+                targets.add(pname.lower())
+
+        if not targets:
+            self._log("No orphaned INIs to clean.")
+            return
+
+        # Confirmation dialog
+        ok = tkmb.askyesno(
+            title="Clean Orphaned INIs",
+            message=(
+                f"Delete SkyGen-generated INI files for {len(targets)} plugin(s) "
+                "that cannot be disabled?\n\n"
+                "This removes INIs in the SkyGen BOS and SkyGen SkyPatcher "
+                "output mods. INIs that ship with original mods are not affected."
+            ),
+            icon="warning",
+        )
+        if not ok:
+            return
+
+        deleted = 0
+        found = 0
+        _for_re = re.compile(r"for\s+([^\s\r\n]+\.es[pml])", re.I)
+        _extensions = (".esp", ".esm", ".esl")
+
+        def _resolve_plugin(ini: Path, is_sp: bool = False) -> Optional[str]:
+            """Derive target plugin name from INI. Tries .esp/.esm/.esl against target set."""
+            try:
+                header = ini.read_text(encoding="utf-8", errors="ignore")[:512]
+            except OSError:
+                self._log(f"  Cannot read {ini}")
+                return None
+            m = _for_re.search(header)
+            if m:
+                raw = m.group(1).lower()
+                if raw in targets:
+                    return raw
+                # Regex may have captured only part of a space-containing name.
+                # Fall through to stem logic below.
+            stem = ini.stem.lower()
+            if is_sp:
+                stem = re.sub(r"^[0-9a-f]+-", "", stem)
+                if stem.endswith("_skygen"):
+                    stem = stem[:-7]
+            else:
+                for suffix in ("_skygen_swap", "_swap"):
+                    if stem.endswith(suffix):
+                        stem = stem[:-len(suffix)]
+                        break
+            # Try each extension against the target set
+            for ext in _extensions:
+                candidate = stem + ext
+                if candidate in targets:
+                    return candidate
+            # Fallback — caller checks ``pkey in targets`` so this won't match
+            return stem + ".esp"
+
+        # Only scan SkyGen output directories — never touch mod-author-supplied INIs
+        skygen_mods = ("SkyGen BOS", "SkyGen SkyPatcher")
+        for mod_name in skygen_mods:
+            mod_dir = mods_path / mod_name
+            if not mod_dir.is_dir():
+                continue
+
+            # BOS: SKSE/Plugins/Data/Base Object Swapper/
+            bos_dir = mod_dir / "SKSE" / "Plugins" / "Data" / "Base Object Swapper"
+            if bos_dir.is_dir():
+                for ini in list(bos_dir.rglob("*.ini")):
+                    if not ini.is_file():
+                        continue
+                    found += 1
+                    pkey = _resolve_plugin(ini, is_sp=False)
+                    if pkey and pkey in targets:
+                        try:
+                            ini.unlink()
+                            deleted += 1
+                            self._log(f"  Deleted {ini.name}")
+                        except OSError as exc:
+                            self._log(f"  Cannot delete {ini}: {exc}")
+                    else:
+                        self._log(f"  Skipped {ini.name} (plugin '{pkey}' not in blocked list)")
+
+            # SkyPatcher
+            for sp_name in ("SkyPatcher", "SkyPatcher2"):
+                sp_dir = mod_dir / "SKSE" / "Plugins" / sp_name
+                if not sp_dir.is_dir():
+                    continue
+                for ini in list(sp_dir.rglob("*.ini")):
+                    if not ini.is_file():
+                        continue
+                    found += 1
+                    pkey = _resolve_plugin(ini, is_sp=True)
+                    if pkey and pkey in targets:
+                        try:
+                            ini.unlink()
+                            deleted += 1
+                            self._log(f"  Deleted {ini.name}")
+                        except OSError as exc:
+                            self._log(f"  Cannot delete {ini}: {exc}")
+                    else:
+                        self._log(f"  Skipped {ini.name} (plugin '{pkey}' not in blocked list)")
+                break
+
+        self._log(f"Cleanup: scanned {found} INI file(s) across all mods, deleted {deleted} orphaned INI(s) for {len(targets)} plugin(s).")
+        self._show_cleanup_result(deleted)
+
+    def _show_cleanup_result(self, deleted: int) -> None:
+        """Result page after cleanup with Re-Scan button."""
+        plugin_count = len([
+            p for p, e in self._entries.items()
+            if not e.can_disable and e.is_patched
+        ])
+        self._clear_body()
+        ctk.CTkLabel(
+            self._body,
+            text="\u2705 Cleanup Complete" if deleted else "\u26a0 No INIs Found",
+            font=FONT_BOLD, text_color="#6bc76b" if deleted else "#e0c45b",
+        ).pack(pady=(16, 8))
+
+        ctk.CTkLabel(
+            self._body,
+            text=(
+                f"Removed {deleted} INI file(s) for {plugin_count} plugin(s)."
+                if deleted
+                else "No matching INI files were found for the blocked plugins."
+            ),
+            font=FONT_NORMAL, text_color=TEXT_DIM, wraplength=380,
+        ).pack(pady=(0, 16))
+
+        ctk.CTkButton(
+            self._body, text="Re-Scan to Verify",
+            width=160, height=40,
+            font=FONT_BOLD,
+            fg_color=ACCENT, hover_color=ACCENT_HOV, text_color=TEXT_ON_ACCENT,
+            command=self._show_scan_step,
+        ).pack()

--- a/src/wizards/plugin_audit.py
+++ b/src/wizards/plugin_audit.py
@@ -169,7 +169,7 @@ def _find_plugin_file(plugin_name: str, mods_path: Path,
     # 2. Vanilla data dir
     if result is None:
         try:
-            data_path = game.get_game_folder() / "Data" / plugin_name
+            data_path = game.get_game_path() / "Data" / plugin_name
             if data_path.is_file():
                 result = data_path
         except Exception:

--- a/src/wizards/plugin_audit.py
+++ b/src/wizards/plugin_audit.py
@@ -720,8 +720,12 @@ class PluginAuditWizard(ctk.CTkFrame):
                 entry.dependents = master_to_deps.get(pname.lower(), [])
 
             # Transitive safe-set resolution
+            # has_new_records plugins cannot be disabled, so they must NOT enter
+            # safe_set — otherwise plugins they depend on are wrongly
+            # marked safe and their orphaned INIs are missed on the
+            # first cleanup pass.
             def _is_patched(e: AuditEntry) -> bool:
-                return e.is_patched
+                return e.is_patched and not e.has_new_records
 
             safe_set: Set[str] = set()
             changed = True

--- a/src/wizards/skygen.py
+++ b/src/wizards/skygen.py
@@ -1,0 +1,1529 @@
+"""
+skygen.py — BOS/SkyPatcher patch generator wizard.
+
+Adapted from SkyGen (Mayhem). Replaces MO2/PyQt6 layer for native Amethyst use.
+Step 1: Scan load order. Step 2: Generate INI patches.
+"""
+
+from __future__ import annotations
+
+import mmap
+import re
+import struct
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+
+import customtkinter as ctk
+
+if TYPE_CHECKING:
+    from Games.base_game import BaseGame
+
+from gui.theme import (
+    ACCENT,
+    ACCENT_HOV,
+    BG_DEEP,
+    BG_HEADER,
+    BG_PANEL,
+    FONT_BOLD,
+    FONT_NORMAL,
+    TEXT_DIM,
+    TEXT_MAIN,
+    TEXT_ON_ACCENT,
+)
+
+# Frankensnoop — pure Python plugin parser (no MO2/PyQt6)
+
+BASE_GAME_PLUGINS: Set[str] = {
+    "Skyrim.esm", "Update.esm", "Dawnguard.esm",
+    "HearthFires.esm", "Dragonborn.esm",
+    "_ResourcePack.esl", "SkyrimVR.esm",
+}
+
+GLOBAL_IGNORE_PLUGINS: Set[str] = {
+    "Skyrim.esm", "Update.esm", "Dawnguard.esm",
+    "HearthFires.esm", "Dragonborn.esm",
+    "_ResourcePack.esl", "SkyrimVR.esm",
+}
+
+# Signatures indicating pure framework/utility mods
+GLOBAL_FRAMEWORK_SIGNATURES: Set[str] = {
+    "SCPT", "SKSE", "SNDR", "SOUN", "CLMT", "WTHR", "MESG",
+    "DLBR", "GMST", "KYWD",
+}
+
+# Protected authors (Bethesda/CC)
+PROTECTED_AUTHORS: Set[str] = {
+    "creationclub", "cc", "bethesda game studios",
+    "bethesda", "mcarofano", "bnesmith", "rsalvatore",
+}
+
+# BOS Categories — must be defined before BOS_SIGS
+BOS_CATEGORIES: Dict[str, Set[str]] = {
+    "Tree": {"TREE"},
+    "Furniture": {"FURN", "MSTT"},
+    "Container": {"CONT"},
+    "Light": {"LIGH"},
+    "Misc": {"STAT", "ACTI", "DOOR", "FLOR"},
+    "Body": {"ARMO", "ARMA", "NPC_", "RACE"},
+    "Skin": {"ARMO", "ARMA", "NPC_", "RACE", "ASSET_SKIN", "ASSET_BODY"},
+}
+
+# BOS-eligible signatures — static objects BOS can swap
+BOS_SIGS: Set[str] = set()
+for _sigs in BOS_CATEGORIES.values():
+    BOS_SIGS.update(_sigs)
+
+# SkyPatcher-eligible signatures
+SP_SIGS: Set[str] = {
+    "NPC_", "WEAP", "ARMO", "AMMO", "ALCH", "BOOK", "LVLI", "LVLN", "FLST",
+    "SPEL", "RACE", "ARMA", "HDPT", "HAIR", "FURN", "INGR", "KEYM",
+}
+
+# Signature → category mapping (BOS vs SkyPatcher)
+SIGNATURE_TO_CATEGORIES: Dict[str, List[str]] = {
+    "ARMO": ["Armor", "SkyPatcher"],
+    "WEAP": ["Weapons", "SkyPatcher"],
+    "AMMO": ["Ammo", "SkyPatcher"],
+    "BOOK": ["Books", "SkyPatcher"],
+    "ALCH": ["Alchemy", "SkyPatcher"],
+    "INGR": ["Ingredients", "SkyPatcher"],
+    "MISC": ["Misc", "BOS"],
+    "STAT": ["Statics", "BOS"],
+    "FURN": ["Furniture", "BOS"],
+    "CONT": ["Containers", "BOS"],
+    "LIGH": ["Lights", "BOS"],
+    "DOOR": ["Doors", "BOS"],
+    "ACTI": ["Activators", "BOS"],
+    "TREE": ["Trees", "BOS"],
+    "FLOR": ["Flora", "BOS"],
+    "NPC_": ["NPCs", "SkyPatcher"],
+    "SPEL": ["Spells", "SkyPatcher"],
+    "RACE": ["Races", "SkyPatcher"],
+    "LVLI": ["Leveled Items", "SkyPatcher"],
+    "LVLN": ["Leveled NPCs", "SkyPatcher"],
+    "FLST": ["Form Lists", "SkyPatcher"],
+}
+
+LOGIC_SIGS: Set[str] = {
+    "QUST", "MGEF", "KYWD", "VMAD", "SCRP", "DLBR", "INFO", "DIAL",
+}
+
+# SkyPatcher example action per record signature
+_SP_EXAMPLE_ACTION: Dict[str, str] = {
+    "NPC_":  "SetEssential=0",
+    "ARMO":  "SetWeight=0",
+    "WEAP":  "SetWeight=0",
+    "AMMO":  "SetWeight=0",
+    "ALCH":  "SetWeight=0",
+    "BOOK":  "SetWeight=0",
+    "MISC":  "SetWeight=0",
+    "INGR":  "SetWeight=0",
+    "KEYM":  "SetWeight=0",
+    "LVLI":  "ChangeChance=100",
+    "LVLN":  "ChangeChance=100",
+    "FLST":  "; AddToFormList=Skyrim.esm|<FormID>",
+    "SPEL":  "; addSpell=Skyrim.esm|<FormID>",
+    "RACE":  "; AddSpell=Skyrim.esm|<FormID>",
+    "ARMA":  "; SetRace=Skyrim.esm|<FormID>",
+    "HDPT":  "; SetRace=Skyrim.esm|<FormID>",
+    "FURN":  "; SetKeyword=Skyrim.esm|<FormID>",
+}
+_SCENT_PATTERNS: Dict[str, re.Pattern] = {
+    "SKSE":       re.compile(r"SKSE|skse|Script Extender", re.I),
+    "DynDOLOD":   re.compile(r"DynDOLOD|dyndolod|LOD", re.I),
+    "xEdit":      re.compile(r"SSEEdit|xEdit|TES5Edit|FO4Edit", re.I),
+    "Synthesis":  re.compile(r"Synthesis|Mutagen", re.I),
+    "Menu":       re.compile(r"SkyUI|AddItemMenu|RaceMenu|UIExtensions", re.I),
+    "MCMHelper":  re.compile(r"MCMHelper|MCM", re.I),
+    "PapyrusUtil": re.compile(r"PapyrusUtil", re.I),
+    "ConsoleUtil": re.compile(r"ConsoleUtil", re.I),
+    "JContainers": re.compile(r"JContainers", re.I),
+    "AddressLib": re.compile(r"Address.*Library", re.I),
+    "PO3":        re.compile(r"powerofthree|po3", re.I),
+    "SPID":       re.compile(r"SPID|Spell.*Perk", re.I),
+    "Framework":  re.compile(r"Framework|Base Object Swapper|Papyrus Extender|Address Library", re.I),
+    "Engine":     re.compile(r"Engine Fixes|Bug Fixes|SSE Fixes", re.I),
+    "BaseObjectSwapper": re.compile(r"BaseObjectSwapper|_SWAP\.ini", re.I),
+    "SkyPatcher": re.compile(r"SkyPatcher", re.I),
+    "AnimationFramework": re.compile(r"XPMSE|XP32|FNIS|Nemesis", re.I),
+}
+_BLACKLIST_AUTHORS = {
+    "jaxonz", "expired6978", "meh321", "sheson", "doodlum",
+    "powerofthree", "ryan-rsm-mckenzie", "aers", "nu_p_p",
+    "tudoran", "towawot", "umgak", "versuchdrei", "xenius",
+    "maskedrpgfan", "andrelo12", "krisv777", "edzio", "gopher",
+    "banjobunny", "acro", "nemesis", "xpmse", "team xpmse", "groovtama",
+    "mrowka", "colinswrath", "po3", "erkeil",
+}
+
+
+@dataclass
+class PluginDNA:
+    """Minimal plugin fingerprint — sufficient for the audit + patch gen."""
+    plugin_name:   str
+    signatures:    Set[str]
+    author:        str
+    masters:       List[str]
+    folder_scents: Set[str] = field(default_factory=set)
+    file_size:     int = 0
+    dependents:    List[str] = field(default_factory=list)  # plugins that list this as a master
+
+    @property
+    def has_dependents(self) -> bool:
+        return bool(self.dependents)
+
+    @property
+    def is_framework(self) -> bool:
+        """True if this is a patcher/engine, not a content mod.
+        
+        Checks folder scents, author blacklist, masters-only plugins,
+        and framework-only signatures.
+        """
+        if "BOS_FRAMEWORK" in self.folder_scents or "SKYPATCHER_FRAMEWORK" in self.folder_scents:
+            return True
+        al = self.author.lower()
+        if any(a in al for a in _BLACKLIST_AUTHORS):
+            return True
+        if not self.signatures and self.masters:
+            return True
+    # Framework-only signatures
+        if self.signatures and self.signatures <= GLOBAL_FRAMEWORK_SIGNATURES:
+            return True
+        return False
+
+    @property
+    def pre_patched_bos(self) -> bool:
+        return "PRE_PATCHED_BOS" in self.folder_scents
+
+    @property
+    def pre_patched_sp(self) -> bool:
+        return "PRE_PATCHED_SP" in self.folder_scents
+
+    @property
+    def pre_patched_bashed(self) -> bool:
+        return "PRE_PATCHED_BASHED" in self.folder_scents
+
+    @property
+    def is_micro(self) -> bool:
+        return "MICRO_FILE" in self.folder_scents
+
+    @property
+    def can_disable(self) -> bool:
+        """True if patch exists AND no plugin depends on this as a master."""
+        if self.has_dependents:
+            return False
+        return (self.pre_patched_bos or self.pre_patched_sp or self.pre_patched_bashed
+                or "PRE_PATCHED_SPID" in self.folder_scents
+                or "PRE_PATCHED_KID" in self.folder_scents
+                or "PRE_PATCHED_DSD" in self.folder_scents
+                or "PRE_PATCHED_OAR" in self.folder_scents
+                or "PRE_PATCHED_SYNTHESIS" in self.folder_scents)
+
+    @property
+    def unsafe_reason(self) -> str:
+        """Why this plugin can't be disabled. Empty if safe."""
+        if self.has_dependents:
+            deps = ", ".join(self.dependents[:5])
+            extra = f" (+{len(self.dependents)-5} more)" if len(self.dependents) > 5 else ""
+            return f"Required by: {deps}{extra}"
+        return ""
+
+    @property
+    def disable_reason(self) -> str:
+        reasons = []
+        if self.pre_patched_bos:
+            reasons.append("Base Object Swapper patch found")
+        if self.pre_patched_sp:
+            reasons.append("SkyPatcher INI patch found")
+        if "PRE_PATCHED_SPID" in self.folder_scents:
+            reasons.append("SPID distributor INI found")
+        if "PRE_PATCHED_KID" in self.folder_scents:
+            reasons.append("KID distributor INI found")
+        if "PRE_PATCHED_DSD" in self.folder_scents:
+            reasons.append("DSD JSON/YAML patch found")
+        if "PRE_PATCHED_OAR" in self.folder_scents:
+            reasons.append("OAR animation replacer found")
+        if "PRE_PATCHED_SYNTHESIS" in self.folder_scents:
+            reasons.append("Synthesis patcher output")
+        if self.pre_patched_bashed:
+            reasons.append("Bashed Patch merged")
+        return " + ".join(reasons) if reasons else ""
+
+    @property
+    def bos_eligible(self) -> bool:
+        """True if plugin has static object signatures (STAT, DOOR, FURN, etc.) eligible for BOS.
+        
+        Excludes Body/Skin unless pluginless body mod.
+        """
+        # Get static object signatures from BOS_CATEGORIES (exclude "Body"/"Skin" which are for pluginless mods)
+        static_sigs = set()
+        for cat_name, sigs in BOS_CATEGORIES.items():
+            if cat_name in ("Body", "Skin"):
+                continue  # pluginless body mods only
+            static_sigs.update(sigs)
+
+        has_static = bool(self.signatures & static_sigs)
+        is_pluginless_body = "ASSET_SKIN" in self.folder_scents or "ASSET_BODY" in self.folder_scents
+
+        if is_pluginless_body:
+            return True
+
+        return has_static
+
+    @property
+    def sp_eligible(self) -> bool:
+        return bool(self.signatures & SP_SIGS)
+
+
+def _scan_memoryview(mv) -> Tuple[Set[str], bool]:
+    """Scan a bytes-like object for GRUP signatures."""
+    signatures: Set[str] = set()
+    if len(mv) < 24 or bytes(mv[:4]) != b"TES4":
+        return signatures, False
+    tes4_size = int.from_bytes(bytes(mv[4:8]), "little")
+    offset = 24 + tes4_size
+    if offset >= len(mv):
+        return signatures, True
+    file_len = len(mv)
+    while offset < file_len - 24:
+        if bytes(mv[offset:offset + 4]) == b"GRUP":
+            rt = bytes(mv[offset + 8:offset + 12]).decode("ascii", errors="ignore")
+            if len(rt) == 4 and rt.replace("_", "").isalnum():
+                signatures.add(rt)
+            grup_size = int.from_bytes(bytes(mv[offset + 4:offset + 8]), "little")
+            if grup_size < 24:
+                break
+            offset += grup_size
+        else:
+            offset += 1
+    return signatures, True
+
+
+def _extract_records(path: Path, wanted_sigs: Set[str]) -> List[Dict]:
+    """Extract FormIDs for records matching *wanted_sigs*.
+    
+    Returns [{form_id, local_id, signature, editor_id, name}].
+    Walks GRUP blocks only (skips TES4 header). Safe from bg thread.
+    """
+    records: List[Dict] = []
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return records
+
+    if len(data) < 24 or data[:4] != b"TES4":
+        return records
+
+    tes4_size = int.from_bytes(data[4:8], "little")
+    offset = 24 + tes4_size
+    file_len = len(data)
+    wanted_bytes = {s.encode("ascii") for s in wanted_sigs}
+
+    while offset < file_len - 24:
+        tag = data[offset:offset + 4]
+        if tag == b"GRUP":
+            grup_size = int.from_bytes(data[offset + 4:offset + 8], "little")
+            grup_type_sig = data[offset + 8:offset + 12]
+            if grup_size < 24:
+                offset += 1
+                continue
+            if grup_type_sig in wanted_bytes:
+                # Walk records inside this GRUP
+                rec_offset = offset + 24
+                grup_end = offset + grup_size
+                sig_str = grup_type_sig.decode("ascii", errors="ignore")
+                while rec_offset < grup_end - 24:
+                    rec_tag = data[rec_offset:rec_offset + 4]
+                    rec_size = int.from_bytes(data[rec_offset + 4:rec_offset + 8], "little")
+                    rec_flags = int.from_bytes(data[rec_offset + 8:rec_offset + 12], "little")
+                    form_id_raw = int.from_bytes(data[rec_offset + 12:rec_offset + 16], "little")
+                    rec_start = rec_offset + 24
+                    rec_end = rec_start + rec_size
+                    if rec_tag == b"GRUP":
+                        # Nested GRUP (cell children etc.) — skip
+                        nested_size = int.from_bytes(data[rec_offset + 4:rec_offset + 8], "little")
+                        rec_offset += max(nested_size, 24)
+                        continue
+                    if rec_end > file_len or rec_size > 10 * 1024 * 1024:
+                        rec_offset += 24
+                        continue
+                    is_compressed = bool(rec_flags & 0x00040000)
+                    edid = ""
+                    full_name = ""
+                    if not is_compressed and rec_size > 0:
+                        # Parse subrecords for EDID and FULL only
+                        sub = rec_start
+                        while sub < rec_end - 6:
+                            sub_tag = data[sub:sub + 4]
+                            # handle XXXX extended-length subrecord
+                            if sub_tag == b"XXXX":
+                                sub_len = int.from_bytes(data[sub + 4:sub + 8], "little")
+                                sub += 8
+                                if sub + 4 > rec_end:
+                                    break
+                                sub_tag = data[sub:sub + 4]
+                                sub += 6
+                            else:
+                                sub_len = int.from_bytes(data[sub + 4:sub + 6], "little")
+                                sub += 6
+                            if sub + sub_len > rec_end:
+                                break
+                            if sub_tag == b"EDID":
+                                raw = data[sub:sub + sub_len]
+                                edid = raw.split(b"\x00")[0].decode("ascii", errors="ignore").strip()
+                            elif sub_tag == b"FULL":
+                                raw = data[sub:sub + sub_len]
+                                full_name = raw.split(b"\x00")[0].decode("utf-8", errors="ignore").strip()
+                                if not full_name:
+                                    # FULL may be a localised string index (4 bytes) — skip
+                                    pass
+                            sub += sub_len
+                    if form_id_raw:
+                        fid_str = f"{form_id_raw:08X}"
+                        local_id = fid_str[-6:]
+                        records.append({
+                            "form_id": fid_str,
+                            "local_id": local_id,
+                            "editor_id": edid,
+                            "name": full_name,
+                            "signature": sig_str,
+                        })
+                    rec_offset = rec_end
+            offset += grup_size
+        else:
+            offset += 1
+    return records
+
+
+
+def _extract_signatures(path: Path) -> Set[str]:
+    try:
+        with open(path, "rb") as f:
+            try:
+                with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+                    sigs, ok = _scan_memoryview(mm)
+                    if ok:
+                        return sigs
+            except (OSError, ValueError, mmap.error):
+                pass
+            f.seek(0)
+            data = f.read()
+            sigs, _ = _scan_memoryview(memoryview(data))
+            return sigs
+    except Exception:
+        return set()
+
+
+def _parse_header(path: Path) -> Tuple[str, List[str]]:
+    """Return (author, [masters])."""
+    try:
+        with open(path, "rb") as f:
+            data = f.read(8192)
+        if len(data) < 24 or data[:4] != b"TES4":
+            return "Unknown", []
+        tes4_size = int.from_bytes(data[4:8], "little")
+        offset, end = 24, min(24 + tes4_size, len(data))
+        author, masters = "Unknown", []
+        while offset < end - 6:
+            st = data[offset:offset + 4]
+            ss = int.from_bytes(data[offset + 4:offset + 6], "little")
+            offset += 6
+            if offset + ss > len(data):
+                break
+            chunk = data[offset:offset + ss]
+            if chunk and chunk[-1] == 0:
+                chunk = chunk[:-1]
+            text = chunk.decode("utf-8", errors="ignore").strip()
+            if st == b"CNAM":
+                author = text or "Unknown"
+            elif st == b"MAST" and text:
+                masters.append(text)
+            offset += ss
+        return author, masters
+    except Exception:
+        return "Unknown", []
+
+
+def _detect_scents(plugin_path: Path, mod_folder: Optional[Path]) -> Set[str]:
+    scents: Set[str] = set()
+    if mod_folder and mod_folder.is_dir():
+        stem = plugin_path.stem
+        name = plugin_path.name
+        # Search mod root + FOMOD Data/ subfolder
+        search_roots = [mod_folder]
+        data_sub = mod_folder / "Data"
+        if data_sub.is_dir():
+            search_roots.append(data_sub)
+
+        for search_root in search_roots:
+            # BOS: <stem>_SWAP.ini anywhere in mod
+            try:
+                for f in search_root.rglob("*.ini"):
+                    if f.is_file() and f.name.lower() == f"{stem.lower()}_swap.ini":
+                        scents.add("PRE_PATCHED_BOS")
+                        scents.add("BOS_FRAMEWORK")
+                        break
+            except OSError:
+                pass
+            # Also check SKSE/Plugins/Data/Base Object Swapper/
+            bos_dir = search_root / "SKSE" / "Plugins" / "Data" / "Base Object Swapper"
+            if bos_dir.is_dir():
+                try:
+                    for ini in bos_dir.rglob("*.ini"):
+                        txt = ini.read_text(encoding="utf-8", errors="ignore")
+                        if name in txt or stem in txt:
+                            scents.add("PRE_PATCHED_BOS")
+                            scents.add("BOS_FRAMEWORK")
+                            break
+                except Exception:
+                    pass
+
+        # SkyPatcher: SKSE/Plugins/SkyPatcher/ or SkyPatcher2/
+        for sp_dir_name in ("SkyPatcher", "SkyPatcher2"):
+            sp_dir = mod_folder / "SKSE" / "Plugins" / sp_dir_name
+            if sp_dir.is_dir():
+                scents.add("SKYPATCHER_FRAMEWORK")
+                try:
+                    for ini in sp_dir.rglob("*.ini"):
+                        chunk = ini.read_text(encoding="utf-8", errors="ignore")[:2048]
+                        if name in chunk or stem in chunk:
+                            scents.add("PRE_PATCHED_SP")
+                            break
+                except Exception:
+                    pass
+                break
+
+        # Additional patch frameworks
+        for search_root in search_roots:
+            # SPID: <stem>_DISTR.ini
+            try:
+                for f in search_root.rglob("*.ini"):
+                    if f.is_file() and f.name.lower() == f"{stem.lower()}_distr.ini":
+                        scents.add("PRE_PATCHED_SPID")
+                        break
+            except OSError:
+                pass
+            # KID: <stem>_KID.ini
+            try:
+                for f in search_root.rglob("*.ini"):
+                    if f.is_file() and f.name.lower() == f"{stem.lower()}_kid.ini":
+                        scents.add("PRE_PATCHED_KID")
+                        break
+            except OSError:
+                pass
+            # DSD: <stem>_DSD.json / _DSD.yaml
+            try:
+                for f in search_root.rglob("*.json"):
+                    if f.is_file() and f.name.lower() == f"{stem.lower()}_dsd.json":
+                        scents.add("PRE_PATCHED_DSD")
+                        break
+            except OSError:
+                pass
+            try:
+                for f in search_root.rglob("*.yaml"):
+                    if f.is_file() and f.name.lower() == f"{stem.lower()}_dsd.yaml":
+                        scents.add("PRE_PATCHED_DSD")
+                        break
+            except OSError:
+                pass
+
+        # OAR: SKSE/Plugins/OpenAnimationReplacer/
+        oar_dir = mod_folder / "SKSE" / "Plugins" / "OpenAnimationReplacer"
+        if oar_dir.is_dir():
+            scents.add("PRE_PATCHED_OAR")
+
+        # Synthesis: plugin named Synthesis.esp
+        if stem.lower() == "synthesis":
+            scents.add("PRE_PATCHED_SYNTHESIS")
+
+        # Micro file: < 2 KB ESL stub
+        try:
+            if plugin_path.exists() and plugin_path.stat().st_size < 2 * 1024:
+                scents.add("MICRO_FILE")
+        except Exception:
+            pass
+    # Name-pattern scents
+    for sname, pattern in _SCENT_PATTERNS.items():
+        if pattern.search(plugin_path.name):
+            scents.add(sname)
+    return scents
+
+
+def _sniff_plugin(plugin_path: Path, mod_folder: Optional[Path]) -> PluginDNA:
+    sigs = _extract_signatures(plugin_path)
+    author, masters = _parse_header(plugin_path)
+    scents = _detect_scents(plugin_path, mod_folder)
+    return PluginDNA(
+        plugin_name=plugin_path.name,
+        signatures=sigs,
+        author=author,
+        masters=masters,
+        folder_scents=scents,
+        file_size=plugin_path.stat().st_size if plugin_path.exists() else 0,
+    )
+
+
+def _find_plugin_file(plugin_name: str, mods_path: Path,
+                      data_path: Optional[Path] = None) -> Optional[Path]:
+    """Locate plugin file on disk. Checks Data/, staging mods/, and FOMOD Data/."""
+    if data_path:
+        candidate = data_path / plugin_name
+        if candidate.is_file():
+            return candidate
+    if mods_path and mods_path.is_dir():
+        try:
+            for mod_dir in mods_path.iterdir():
+                if not mod_dir.is_dir():
+                    continue
+                for sub in (mod_dir, mod_dir / "Data"):
+                    candidate = sub / plugin_name
+                    if candidate.is_file():
+                        return candidate
+        except OSError:
+            pass
+    return None
+
+
+# Path helpers
+
+def _read_active_profile(game: "BaseGame") -> str:
+    """Current profile name: _active_profile_dir → last active → default."""
+    # 1. Live profile dir set by Amethyst
+    active_dir = getattr(game, "_active_profile_dir", None)
+    if active_dir is not None:
+        name = Path(active_dir).name
+        if name:
+            return name
+
+    # 2. Persisted last active
+    try:
+        last = game.get_last_active_profile()
+        if last and last != "default":
+            # Verify the profile dir actually exists
+            candidate = game.get_profile_root() / "profiles" / last
+            if candidate.is_dir():
+                return last
+    except Exception:
+        pass
+
+    # 3. First non-default with loadorder.txt, else "default"
+    try:
+        profiles_root = game.get_profile_root() / "profiles"
+        if profiles_root.is_dir():
+            candidates = sorted(
+                d for d in profiles_root.iterdir()
+                if d.is_dir() and d.name != "default" and (d / "loadorder.txt").is_file()
+            )
+            if candidates:
+                return candidates[0].name
+    except Exception:
+        pass
+
+    return "default"
+
+
+def _profile_dir(game: "BaseGame", profile: str) -> Path:
+    return game.get_profile_root() / "profiles" / profile
+
+
+def _read_loadorder(game: "BaseGame", profile: str) -> List[str]:
+    """Return ordered list of *active* plugin names for the given profile."""
+    pdir = _profile_dir(game, profile)
+    lo_path = pdir / "loadorder.txt"
+    pl_path = pdir / "plugins.txt"
+
+    full_order: List[str] = []
+    if lo_path.is_file():
+        for line in lo_path.read_text(encoding="utf-8").splitlines():
+            line = line.split("#")[0].strip()
+            if line:
+                full_order.append(line)
+
+    active_set: Set[str] = set()
+    if pl_path.is_file():
+        for line in pl_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line.startswith("*"):
+                active_set.add(line[1:].strip())
+            elif not line.startswith("#") and line:
+                # Older format without star prefix — treat all as active
+                active_set.add(line)
+
+    if not full_order:
+        return list(active_set)
+
+    # Preserve order, filter to active only (base masters always included)
+    return [p for p in full_order if p in BASE_GAME_PLUGINS or p in active_set]
+
+
+def _find_plugin_file(plugin_name: str, mods_path: Path, data_path: Optional[Path]) -> Optional[Path]:
+    """3-tier search: mods/ → mods/<n>/Data/ → game Data/."""
+    if mods_path.is_dir():
+        for mod_dir in mods_path.iterdir():
+            if not mod_dir.is_dir():
+                continue
+            cand = mod_dir / plugin_name
+            if cand.is_file():
+                return cand
+            cand2 = mod_dir / "Data" / plugin_name
+            if cand2.is_file():
+                return cand2
+    if data_path and data_path.is_dir():
+        cand = data_path / plugin_name
+        if cand.is_file():
+            return cand
+    return None
+
+
+def _build_patch_index(mods_path: Path) -> Tuple[Set[str], Set[str]]:
+    """Scan staging directory for existing patches.
+    
+    Returns (bos_patched, sp_patched) — lower-case plugin name sets.
+    Catches patches in different mods than the target plugin.
+    """
+    bos_patched: Set[str] = set()
+    sp_patched: Set[str] = set()
+
+    if not mods_path or not mods_path.is_dir():
+        return bos_patched, sp_patched
+
+    _for_re = re.compile(r"for\s+([^\s\r\n]+\.es[pml])", re.I)
+
+    try:
+        for mod_dir in mods_path.iterdir():
+            if not mod_dir.is_dir():
+                continue
+
+            # --- BOS: any *_SWAP.ini anywhere in the mod tree ---
+            bos_dir = mod_dir / "SKSE" / "Plugins" / "Data" / "Base Object Swapper"
+            if bos_dir.is_dir():
+                try:
+                    for ini in bos_dir.rglob("*.ini"):
+                        try:
+                            header = ini.read_text(encoding="utf-8", errors="ignore")[:512]
+                        except OSError:
+                            continue
+                        m = _for_re.search(header)
+                        if m:
+                            bos_patched.add(m.group(1).lower())
+                        else:
+                            # Fall back: strip _SkyGen_SWAP / _SWAP suffix from filename
+                            stem = ini.stem.lower()
+                            for suffix in ("_skygen_swap", "_swap"):
+                                if stem.endswith(suffix):
+                                    stem = stem[: -len(suffix)]
+                                    break
+                            # stem could map to .esp/.esm/.esl — try all
+                            for ext in (".esp", ".esm", ".esl"):
+                                bos_patched.add(stem + ext)
+                except OSError:
+                    pass
+
+            # Also catch bare <stem>_SWAP.ini files at mod root (e.g. hand-authored)
+            try:
+                for ini in mod_dir.rglob("*_swap.ini"):
+                    stem = ini.stem.lower()
+                    if stem.endswith("_swap"):
+                        stem = stem[:-5]
+                    for ext in (".esp", ".esm", ".esl"):
+                        bos_patched.add(stem + ext)
+            except OSError:
+                pass
+
+            # --- SkyPatcher: SKSE/Plugins/SkyPatcher[2]/ ---
+            for sp_name in ("SkyPatcher", "SkyPatcher2"):
+                sp_dir = mod_dir / "SKSE" / "Plugins" / sp_name
+                if sp_dir.is_dir():
+                    try:
+                        for ini in sp_dir.rglob("*.ini"):
+                            try:
+                                header = ini.read_text(encoding="utf-8", errors="ignore")[:512]
+                            except OSError:
+                                continue
+                            m = _for_re.search(header)
+                            if m:
+                                sp_patched.add(m.group(1).lower())
+                            else:
+                                # Strip LO prefix (e.g. "1F-") and _SkyGen suffix
+                                stem = ini.stem.lower()
+                                stem = re.sub(r"^[0-9a-f]+-", "", stem)
+                                if stem.endswith("_skygen"):
+                                    stem = stem[:-7]
+                                for ext in (".esp", ".esm", ".esl"):
+                                    sp_patched.add(stem + ext)
+                    except OSError:
+                        pass
+                    break  # found a SP dir, no need to check SP2
+    except OSError:
+        pass
+
+    return bos_patched, sp_patched
+
+
+def _find_mod_folder(plugin_path: Path, mods_path: Path) -> Optional[Path]:
+    """Resolve the mod staging folder that owns this plugin."""
+    try:
+        rel = plugin_path.relative_to(mods_path)
+        # rel is <ModFolder>/... so first part is the mod folder
+        return mods_path / rel.parts[0]
+    except ValueError:
+        return None
+
+
+
+# ---------------------------------------------------------------------------
+# Wizard
+# ---------------------------------------------------------------------------
+
+class SkyGenWizard(ctk.CTkFrame):
+    """BOS/SkyPatcher patch generator. Step 1: scan, Step 2: generate."""
+
+    _wizard_title = "SkyGen — Patch Generator"
+
+    def __init__(
+        self,
+        parent,
+        game: "BaseGame",
+        log_fn=None,
+        *,
+        on_close=None,
+        **_kwargs,
+    ) -> None:
+        super().__init__(parent, fg_color=BG_DEEP, corner_radius=0)
+        self._on_close_cb = on_close or (lambda: None)
+        self._game        = game
+        self._log         = log_fn or print
+        self._dna_map:    Dict[str, PluginDNA] = {}   # plugin_name -> DNA
+        self._plugin_vars: Dict[str, ctk.BooleanVar] = {}  # plugin_name -> checkbox var
+        self._done_fired  = False
+        self._cancel_flag = False
+
+        # ------ Title bar ------
+        tbar = ctk.CTkFrame(self, fg_color=BG_HEADER, corner_radius=0, height=40)
+        tbar.pack(fill="x")
+        tbar.pack_propagate(False)
+        ctk.CTkLabel(
+            tbar,
+            text=f"{self._wizard_title}  —  {game.name}",
+            font=FONT_BOLD, text_color=TEXT_MAIN, anchor="w",
+        ).pack(side="left", padx=12, pady=8)
+        ctk.CTkButton(
+            tbar, text="\u2715", width=32, height=32, font=FONT_BOLD,
+            fg_color="transparent", hover_color=BG_PANEL, text_color=TEXT_MAIN,
+            command=self._close,
+        ).pack(side="right", padx=4, pady=4)
+
+        # ------ Body ------
+        self._body = ctk.CTkFrame(self, fg_color=BG_DEEP)
+        self._body.pack(fill="both", expand=True, padx=12, pady=12)
+
+        self._show_step_scan()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _clear_body(self):
+        for w in self._body.winfo_children():
+            w.destroy()
+
+    def _set_label(self, attr: str, text: str, color: str = TEXT_DIM):
+        def _apply():
+            try:
+                w = getattr(self, attr, None)
+                if w and w.winfo_exists():
+                    w.configure(text=text, text_color=color)
+            except Exception:
+                pass
+        self.after(0, _apply)
+
+    def _log_ui(self, msg: str):
+        self._log(f"[SkyGen] {msg}")
+
+    def _close(self):
+        if self._done_fired:
+            return
+        self._done_fired = True
+        try:
+            topbar = self.winfo_toplevel()._topbar
+        except Exception:
+            topbar = None
+        self._on_close_cb()
+        if topbar:
+            try:
+                topbar.after(0, topbar._reload_mod_panel)
+            except Exception:
+                pass
+
+    def _offer_open_folder(self, out_dir: Path) -> None:
+        """Show button to open output folder in system file manager."""
+        try:
+            # Only add the button once
+            if getattr(self, "_open_folder_btn", None) is not None:
+                return
+            self._open_folder_btn = ctk.CTkButton(
+                self._body,
+                text=f"Open output folder",
+                width=220, height=30,
+                font=FONT_NORMAL,
+                fg_color=BG_PANEL, hover_color="#3d3d3d", text_color=TEXT_DIM,
+                command=lambda: self._xdg_open(out_dir),
+            )
+            self._open_folder_btn.pack(pady=(0, 4))
+        except Exception:
+            pass
+
+    @staticmethod
+    def _xdg_open(path: Path) -> None:
+        import subprocess
+        try:
+            subprocess.Popen(["xdg-open", str(path)])
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Step 1 — Scan
+    # ------------------------------------------------------------------
+
+    def _show_step_scan(self):
+        self._clear_body()
+
+        ctk.CTkLabel(
+            self._body, text="Step 1: Scan Active Plugins",
+            font=FONT_BOLD, text_color=TEXT_MAIN,
+        ).pack(pady=(0, 8))
+
+        info = (
+            "SkyGen will read your active load order and scan every plugin "
+            "for record signatures that Base Object Swapper and SkyPatcher can "
+            "override at runtime. This identifies:"
+            "\n\n  \u2022  Which plugins are eligible for new BOS / SkyPatcher patches "
+            "(override-only STAT, DOOR, FURN, and similar records that BOS can swap)."
+            "\n  \u2022  Which plugins already have patches in place (skipped)."
+            "\n\nNote: Plugins that add their own new records (references, items, "
+            "NPCs) will still need their ESP/ESL loaded even after patching \u2014 "
+            "the INI only swaps existing base forms, it does not create new ones."
+        )
+        ctk.CTkLabel(
+            self._body, text=info,
+            font=FONT_NORMAL, text_color=TEXT_DIM, justify="left", wraplength=380,
+        ).pack(pady=(0, 12), fill="x")
+
+        self._scan_status = ctk.CTkLabel(
+            self._body, text="Ready to scan.",
+            font=FONT_NORMAL, text_color=TEXT_DIM, justify="center", wraplength=380,
+        )
+        self._scan_status.pack(pady=(0, 6))
+
+        self._scan_progress = ctk.CTkProgressBar(self._body)
+        self._scan_progress.set(0)
+        self._scan_progress.pack(fill="x", padx=20, pady=(0, 12))
+
+        btn_row = ctk.CTkFrame(self._body, fg_color="transparent")
+        btn_row.pack(side="bottom", pady=(8, 0))
+
+        ctk.CTkButton(
+            btn_row, text="Cancel", width=100, height=36,
+            font=FONT_BOLD,
+            fg_color=BG_HEADER, hover_color="#3d3d3d", text_color=TEXT_MAIN,
+            command=self._close,
+        ).pack(side="left", padx=(0, 8))
+
+        self._scan_btn = ctk.CTkButton(
+            btn_row, text="Scan \u2192", width=140, height=36,
+            font=FONT_BOLD,
+            fg_color=ACCENT, hover_color=ACCENT_HOV, text_color=TEXT_ON_ACCENT,
+            command=self._start_scan,
+        )
+        self._scan_btn.pack(side="right")
+
+        # Store cancel button reference (created on demand)
+        self._scan_cancel_btn: Optional[ctk.CTkButton] = None
+
+    def _start_scan(self):
+        self._cancel_flag = False
+        self._scan_btn.configure(state="disabled", text="Scanning\u2026")
+        # Show a Cancel button
+        if self._scan_cancel_btn is None:
+            self._scan_cancel_btn = ctk.CTkButton(
+                self._body, text="Cancel", width=100, height=36,
+                font=FONT_BOLD, fg_color=BG_HEADER, hover_color="#3d3d3d",
+                text_color=TEXT_MAIN, command=self._cancel,
+            )
+            self._scan_cancel_btn.pack(before=self._scan_btn, side="right", padx=(0, 8))
+        self._scan_cancel_btn.pack(before=self._scan_btn, side="right", padx=(0, 8))
+        threading.Thread(target=self._do_scan, daemon=True).start()
+
+    def _cancel(self):
+        """Signal the worker thread to stop."""
+        self._cancel_flag = True
+        self._log_ui("Cancelled by user.")
+        self.after(0, self._show_step_scan)
+
+
+    def _do_scan(self):
+        try:
+            game = self._game
+            profile = _read_active_profile(game)
+            self._log_ui(f"Active profile: '{profile}'")
+            lo = _read_loadorder(game, profile)
+            if not lo:
+                self.after(0, lambda: self._set_label(
+                    "_scan_status",
+                    "No active plugins found.\nMake sure a profile is loaded and has an active load order.",
+                    "#e06c6c",
+                ))
+                self.after(0, lambda: self._scan_btn.configure(state="normal", text="Scan"))
+                return
+            # Prefer profile-aware staging path when available
+            get_staging = getattr(game, "get_effective_mod_staging_path", None) or game.get_mod_staging_path
+            mods_path = get_staging()
+            game_path = game.get_game_path()
+            data_path = game_path / "Data" if game_path else None
+
+            total = len(lo)
+            dna_map: Dict[str, PluginDNA] = {}
+
+            # Build a cross-mod patch index once before the plugin loop so we
+            # can flag plugins whose patches live in a different mod folder
+            # (e.g. a SkyGen Output mod, a hand-crafted BOS pack, etc.)
+            self._log_ui("Building cross-mod patch index…")
+            bos_index, sp_index = _build_patch_index(mods_path)
+            self._log_ui(f"Patch index: {len(bos_index)} BOS targets, {len(sp_index)} SP targets")
+
+            for i, plugin_name in enumerate(lo):
+                if self._cancel_flag:
+                    self.after(0, lambda: self._show_step_scan())
+                    return
+                if plugin_name in GLOBAL_IGNORE_PLUGINS:
+                    continue
+                plugin_path = _find_plugin_file(plugin_name, mods_path, data_path)
+                if not plugin_path:
+                    continue
+                mod_folder = _find_mod_folder(plugin_path, mods_path)
+                try:
+                    dna = _sniff_plugin(plugin_path, mod_folder)
+                except Exception as exc:
+                    self._log_ui(f"Sniff failed for {plugin_name}: {exc}")
+                    continue
+                # Apply cross-mod patch index — patches in other mod folders
+                pkey = plugin_name.lower()
+                if pkey in bos_index:
+                    dna.folder_scents.add("PRE_PATCHED_BOS")
+                if pkey in sp_index:
+                    dna.folder_scents.add("PRE_PATCHED_SP")
+                dna_map[plugin_name] = dna
+                # Batch UI updates every 50 plugins to avoid flooding the Tk
+                # event queue with thousands of callbacks for large load orders.
+                if i % 50 == 0 or i == total - 1:
+                    frac = (i + 1) / total if total else 0
+                    self.after(0, lambda f=frac, n=plugin_name, idx=i, t=total: (
+                        self._scan_progress.set(f),
+                        self._set_label("_scan_status",
+                                        f"({idx+1}/{t}) {n}", TEXT_DIM),
+                    ))
+
+            self._dna_map = dna_map
+            self._lo_index_map = {name: i for i, name in enumerate(lo)}
+
+            # --- Bashed Patch coverage ---
+            # Plugins merged into "Bashed Patch, *.esp" are already patched.
+            _bp_masters: Set[str] = set()
+            for pname, dna in dna_map.items():
+                if pname.lower().startswith("bashed patch,"):
+                    for master in dna.masters:
+                        ml = master.lower()
+                        if ml not in BASE_GAME_PLUGINS:
+                            _bp_masters.add(ml)
+            if _bp_masters:
+                for pname, dna in dna_map.items():
+                    if pname.lower() in _bp_masters:
+                        dna.folder_scents.add("PRE_PATCHED_BASHED")
+
+            # Build reverse dependency map — flag any plugin that is listed as a
+            # master by another active plugin so we never recommend disabling it.
+            master_to_dependents: Dict[str, List[str]] = {}
+            for pname, dna in dna_map.items():
+                for master in dna.masters:
+                    master_to_dependents.setdefault(master.lower(), []).append(pname)
+            for pname, dna in dna_map.items():
+                deps = master_to_dependents.get(pname.lower(), [])
+                if deps:
+                    dna.dependents = deps
+
+            # Transitive safe-to-disable resolution:
+            # A patched plugin whose ONLY dependents are themselves patched (and
+            # thus also removable) is also safe to disable.  Iterate until stable.
+            def _is_patched(d: PluginDNA) -> bool:
+                return (d.pre_patched_bos or d.pre_patched_sp or d.pre_patched_bashed
+                        or "PRE_PATCHED_SPID" in d.folder_scents
+                        or "PRE_PATCHED_KID"  in d.folder_scents
+                        or "PRE_PATCHED_DSD"  in d.folder_scents
+                        or "PRE_PATCHED_OAR"  in d.folder_scents
+                        or "PRE_PATCHED_SYNTHESIS" in d.folder_scents)
+
+            safe_set: Set[str] = set()
+            changed = True
+            while changed:
+                changed = False
+                for pname, dna in dna_map.items():
+                    if pname in safe_set:
+                        continue
+                    if not _is_patched(dna):
+                        continue
+                    # All dependents must themselves be in safe_set (or not in
+                    # the active load order at all — e.g. a vanilla master)
+                    all_deps_safe = all(
+                        dep in safe_set or dep not in dna_map
+                        for dep in dna.dependents
+                    )
+                    if all_deps_safe:
+                        safe_set.add(pname)
+                        changed = True
+
+            # Stamp transitively-safe plugins: clear their dependents so
+            # can_disable returns True, but record the original list for the UI.
+            for pname, dna in dna_map.items():
+                if pname in safe_set and dna.dependents:
+                    dna.folder_scents.add("TRANSITIVELY_SAFE")
+                    dna.dependents = []   # unblock can_disable
+            disableable = sum(1 for d in dna_map.values() if d.can_disable)
+            bos_eligible = sum(1 for d in dna_map.values() if d.bos_eligible and not d.is_framework)
+            sp_eligible  = sum(1 for d in dna_map.values() if d.sp_eligible  and not d.is_framework)
+
+            summary = (
+                f"  Plugins scanned:                {len(dna_map)}\n"
+                f"  BOS-eligible for new patches:   {bos_eligible}\n"
+                f"  SkyPatcher-eligible:            {sp_eligible}"
+            )
+            self.after(0, lambda: self._set_label("_scan_status", summary, "#6bc76b"))
+            self.after(300, self._show_step_generate)
+
+        except Exception as exc:
+            import traceback
+            tb = traceback.format_exc()
+            self._log_ui(f"Scan error: {exc}\n{tb}")
+            self.after(0, lambda: self._set_label("_scan_status", f"Error: {exc}", "#e06c6c"))
+
+    # ------------------------------------------------------------------
+    # Step 2 — Generate patches
+    # ------------------------------------------------------------------
+
+    def _show_step_generate(self):
+        self._clear_body()
+        self._plugin_vars.clear()
+
+        ctk.CTkLabel(
+            self._body, text="Step 2: Generate Patches",
+            font=FONT_BOLD, text_color=TEXT_MAIN,
+        ).pack(pady=(0, 8))
+
+        # Mode selector
+        mode_frame = ctk.CTkFrame(self._body, fg_color=BG_PANEL)
+        mode_frame.pack(fill="x", pady=(0, 12))
+        ctk.CTkLabel(mode_frame, text="Output type:", font=FONT_BOLD,
+                     text_color=TEXT_MAIN).grid(row=0, column=0, padx=12, pady=8)
+        self._mode_var = ctk.StringVar(value="BOS")
+        for i, opt in enumerate(("BOS", "SkyPatcher")):
+            ctk.CTkRadioButton(
+                mode_frame, text=opt, variable=self._mode_var, value=opt,
+                font=FONT_NORMAL, text_color=TEXT_MAIN,
+                command=self._refresh_plugin_list,
+            ).grid(row=0, column=i + 1, padx=16, pady=8)
+
+        ctk.CTkLabel(
+            self._body,
+            text=(
+                "Select the plugins to generate patches for. Only override records "
+                "of supported types (STAT, DOOR, FURN, LIGH, MISC, CONT, etc.) are "
+                "extracted. The generated INI will be placed under the SkyGen mod:"
+                f"\n  \u2022 BOS:  SKSE/Plugins/Data/Base Object Swapper/"
+                f"\n  \u2022 SkyPatcher:  SKSE/Plugins/SkyPatcher/"
+            ),
+            font=FONT_NORMAL, text_color=TEXT_DIM, justify="left", wraplength=380,
+        ).pack(fill="x", pady=(0, 12))
+
+        # Select / Deselect buttons
+        select_frame = ctk.CTkFrame(self._body, fg_color="transparent")
+        select_frame.pack(fill="x", pady=(0, 8))
+        ctk.CTkButton(
+            select_frame, text="Select All", width=100, height=28,
+            font=FONT_NORMAL,
+            fg_color=BG_PANEL, hover_color="#3d3d3d", text_color=TEXT_DIM,
+            command=self._select_all_plugins,
+        ).pack(side="left", padx=4)
+        ctk.CTkButton(
+            select_frame, text="Deselect All", width=100, height=28,
+            font=FONT_NORMAL,
+            fg_color=BG_PANEL, hover_color="#3d3d3d", text_color=TEXT_DIM,
+            command=self._deselect_all_plugins,
+        ).pack(side="left", padx=4)
+
+        # Plugin count label
+        self._plugin_count_label = ctk.CTkLabel(
+            select_frame, text="", font=FONT_NORMAL, text_color=TEXT_DIM,
+        )
+        self._plugin_count_label.pack(side="left", padx=12)
+
+        # Scrollable plugin list
+        self._plugin_scroll = ctk.CTkScrollableFrame(
+            self._body, fg_color=BG_PANEL, corner_radius=4,
+        )
+        self._plugin_scroll.pack(fill="both", expand=True, pady=(0, 12))
+
+        self._gen_status = ctk.CTkLabel(
+            self._body, text="",
+            font=FONT_NORMAL, text_color=TEXT_DIM, justify="center", wraplength=380,
+        )
+        self._gen_status.pack(pady=(0, 4))
+
+        # Generate button
+        btn_row = ctk.CTkFrame(self._body, fg_color="transparent")
+        btn_row.pack(side="bottom", pady=(8, 0))
+        ctk.CTkButton(
+            btn_row, text="\u2190 Back", width=100, height=36,
+            font=FONT_BOLD,
+            fg_color=BG_HEADER, hover_color="#3d3d3d", text_color=TEXT_MAIN,
+            command=self._show_step_scan,
+        ).pack(side="left", padx=(0, 8))
+
+        self._gen_btn = ctk.CTkButton(
+            btn_row, text="Generate", width=140, height=36,
+            font=FONT_BOLD,
+            fg_color=ACCENT, hover_color=ACCENT_HOV, text_color=TEXT_ON_ACCENT,
+            command=self._start_generate,
+        )
+        self._gen_btn.pack(side="right")
+
+        # Populate the plugin list
+        self._refresh_plugin_list()
+
+    def _refresh_plugin_list(self):
+        # Clear existing checkboxes
+        for widget in self._plugin_scroll.winfo_children():
+            widget.destroy()
+        self._plugin_vars.clear()
+
+        mode = self._mode_var.get()
+        if mode == "BOS":
+            eligible = {n: d for n, d in self._dna_map.items()
+                        if d.bos_eligible and not d.is_framework and not d.pre_patched_bashed}
+            sig_set = BOS_SIGS
+        else:
+            eligible = {n: d for n, d in self._dna_map.items()
+                        if d.sp_eligible and not d.is_framework and not d.pre_patched_bashed}
+            sig_set = SP_SIGS
+
+        sorted_plugins = sorted(eligible.keys())
+
+        # Update count label
+        self._plugin_count_label.configure(
+            text=f"{len(sorted_plugins)} {mode}-eligible plugins found"
+        )
+
+        if not sorted_plugins:
+            ctk.CTkLabel(
+                self._plugin_scroll, text=f"No {mode}-eligible plugins found.",
+                font=FONT_NORMAL, text_color=TEXT_DIM,
+            ).pack(pady=12)
+            return
+
+        # Add checkboxes for each eligible plugin
+        for plugin_name in sorted_plugins:
+            var = ctk.BooleanVar(value=True)  # preselected by default
+            self._plugin_vars[plugin_name] = var
+            dna = eligible[plugin_name]
+            sigs = ", ".join(sorted(dna.signatures & sig_set))
+            display_name = plugin_name if len(plugin_name) <= 50 else plugin_name[:47] + "..."
+            text = f"{display_name} ({sigs})" if sigs else display_name
+            ctk.CTkCheckBox(
+                self._plugin_scroll, text=text, variable=var,
+                font=FONT_NORMAL, text_color=TEXT_MAIN,
+                checkbox_width=22, checkbox_height=22,
+            ).pack(fill="x", padx=8, pady=2)
+
+    def _select_all_plugins(self):
+        for var in self._plugin_vars.values():
+            var.set(True)
+
+    def _deselect_all_plugins(self):
+        for var in self._plugin_vars.values():
+            var.set(False)
+
+    def _start_generate(self):
+        self._cancel_flag = False
+        self._gen_btn.configure(state="disabled", text="Generating\u2026")
+        # Show a Cancel button
+        if not hasattr(self, "_gen_cancel_btn") or self._gen_cancel_btn is None:
+            self._gen_cancel_btn = ctk.CTkButton(
+                self._body, text="Cancel", width=100, height=36,
+                font=FONT_BOLD, fg_color=BG_HEADER, hover_color="#3d3d3d",
+                text_color=TEXT_MAIN, command=self._cancel,
+            )
+        self._gen_cancel_btn.pack(side="right", padx=(0, 8), before=self._gen_btn)
+        threading.Thread(target=self._do_generate, daemon=True).start()
+
+    def _do_generate(self):
+        try:
+            mode = self._mode_var.get()          # "BOS" or "SkyPatcher"
+            out_name = "SkyGen BOS" if mode == "BOS" else "SkyGen SkyPatcher"
+            get_staging = getattr(self._game, "get_effective_mod_staging_path", None) or self._game.get_mod_staging_path
+            mods_path = get_staging()
+            out_dir = mods_path / out_name
+
+            # Remove previous output so users always get a clean result
+            if out_dir.exists():
+                import shutil
+                shutil.rmtree(out_dir)
+            out_dir.mkdir(parents=True, exist_ok=True)
+
+            if mode == "BOS":
+                written = self._gen_bos(out_dir)
+            else:
+                written = self._gen_skypatcher(out_dir)
+
+            # Register as a managed mod (meta.ini + modlist entry)
+            self._register_output_mod(out_name, out_dir)
+
+            self._log_ui(f"Patch generation complete. Output: {out_dir}")
+            # Show Done step so user sees confirmation, then can close
+            self.after(0, lambda m=mode, w=written, d=out_dir: self._show_step_done(m, w, d))
+
+        except Exception as exc:
+            import traceback
+            tb = traceback.format_exc()
+            self._log_ui(f"Generate error: {exc}\n{tb}")
+            self.after(0, lambda: self._set_label("_gen_status", f"Error: {exc}", "#e06c6c"))
+            self.after(0, lambda: self._gen_btn.configure(
+                state="normal", text="Generate", command=self._start_generate
+            ))
+            if hasattr(self, "_gen_cancel_btn") and self._gen_cancel_btn:
+                self.after(0, lambda: self._gen_cancel_btn.pack_forget())
+
+    def _register_output_mod(self, mod_name: str, mod_dir: Path) -> None:
+        """Write meta.ini and prepend the mod to modlist.txt so Amethyst treats
+        the output folder as a managed, enabled mod — same pattern as Pandora."""
+        from Nexus.nexus_meta import NexusModMeta, write_meta
+        from Utils.modlist import prepend_mod
+
+        meta = NexusModMeta(mod_name=mod_name, installation_file="SkyGen", root_folder=False)
+        write_meta(mod_dir / "meta.ini", meta)
+
+        # Resolve active profile modlist
+        try:
+            profile = _read_active_profile(self._game)
+        except Exception:
+            profile = "default"
+        modlist_path = _profile_dir(self._game, profile) / "modlist.txt"
+        if not modlist_path.is_file():
+            # Fallback: try profile root directly
+            modlist_path = self._game.get_profile_root() / "modlist.txt"
+
+        prepend_mod(modlist_path, mod_name, enabled=True)
+        self._log_ui(f"Registered '{mod_name}' in modlist as enabled mod.")
+
+        # Trigger mod panel refresh if reachable
+        try:
+            toplevel = self.winfo_toplevel()
+            mod_panel = getattr(toplevel, "_mod_panel", None)
+            if mod_panel is not None:
+                mod_panel.after(0, mod_panel.reload_after_install)
+        except Exception:
+            pass
+
+    def _gen_bos(self, out_dir: Path) -> None:
+        """Write BOS swap INIs using object names (EditorIDs).
+
+        Format: sourceObject|replacementObject|NONE|chanceR(percent)
+        Based on real-world BOS INI examples.
+        """
+        bos_dir = out_dir / "SKSE" / "Plugins" / "Data" / "Base Object Swapper"
+        bos_dir.mkdir(parents=True, exist_ok=True)
+        lo_map = getattr(self, "_lo_index_map", {})
+
+        written = 0
+        for plugin_name, dna in self._dna_map.items():
+            if self._cancel_flag:
+                break
+            if not dna.bos_eligible or dna.is_framework:
+                continue
+            var = self._plugin_vars.get(plugin_name)
+            if not var or not var.get():
+                continue
+            bos_sigs = dna.signatures & BOS_SIGS
+            if not bos_sigs:
+                continue
+
+            get_staging = getattr(self._game, "get_effective_mod_staging_path", None) or self._game.get_mod_staging_path
+            mods_path = get_staging()
+            game_path = self._game.get_game_path()
+            data_path = game_path / "Data" if game_path else None
+            plugin_path = _find_plugin_file(plugin_name, mods_path, data_path)
+
+            records = _extract_records(plugin_path, bos_sigs) if plugin_path else []
+
+            stem = Path(plugin_name).stem
+            out_ini = bos_dir / f"{stem}_SkyGen_SWAP.ini"
+            lines = [
+                f"; Auto-generated by SkyGen (Amethyst) for {plugin_name}",
+                f"; Record types: {', '.join(sorted(bos_sigs))}",
+                "; Format: sourceObject|replacementObject|NONE|chanceR(percent)",
+                "; Edit the right side and chance values for your setup.",
+                "[Forms]",
+                "",
+            ]
+            if records:
+                    for rec in records:
+                        label = rec["editor_id"] or rec["name"] or rec["local_id"]
+                        # BOS format: 0x{local_id}~PluginName|0x{local_id}~ReplacementPlugin|props|chance
+                        # Left side: object being replaced (from scanned plugin)
+                        # Right side: replacement (user edits this)
+                        orig = f"0x{rec['local_id']}~{plugin_name}"
+                        placeholder = f"0x{rec['local_id']}~<ReplacementPlugin>"
+                        entry = f"{orig}|{placeholder}|NONE|chanceR(100)"
+                        lines.append(f"; [{rec['signature']}] {label}")
+                        lines.append(entry)
+                    lines.append("")
+            else:
+                lines += [
+                    f"; Could not extract records from {plugin_name}.",
+                    f"; Format: objectName|replacementName|NONE|chanceR(100)",
+                ]
+
+            out_ini.write_text("\n".join(lines), encoding="utf-8")
+            written += 1
+            self._log_ui(f"BOS: {out_ini.name} ({len(records)} records)")
+
+        self._log_ui(f"BOS done: {written} INIs written to {bos_dir}")
+        return written
+
+    def _gen_skypatcher(self, out_dir: Path) -> int:
+        """Write SkyPatcher INIs with filterByFormID entries.
+        Returns number of INI files written."""
+        sp_dir = out_dir / "SKSE" / "Plugins" / "SkyPatcher"
+        sp_dir.mkdir(parents=True, exist_ok=True)
+        lo_map = getattr(self, "_lo_index_map", {})
+
+        written = 0
+        for plugin_name, dna in self._dna_map.items():
+            if self._cancel_flag:
+                break
+            if not dna.sp_eligible or dna.is_framework:
+                continue
+            # Check if plugin is selected by user
+            var = self._plugin_vars.get(plugin_name)
+            if not var or not var.get():
+                continue
+            sp_sigs = dna.signatures & SP_SIGS
+            if not sp_sigs:
+                continue
+
+            get_staging = getattr(self._game, "get_effective_mod_staging_path", None) or self._game.get_mod_staging_path
+            mods_path = get_staging()
+            game_path = self._game.get_game_path()
+            data_path = game_path / "Data" if game_path else None
+            plugin_path = _find_plugin_file(plugin_name, mods_path, data_path)
+
+            records = _extract_records(plugin_path, sp_sigs) if plugin_path else []
+
+            # Use LO-index prefix for filename: ESL → FExx, others → 2-digit hex
+            lo_idx = lo_map.get(plugin_name, 999)
+            if plugin_name.lower().endswith(".esl"):
+                prefix = f"FE{lo_idx:03X}"
+            else:
+                prefix = f"{lo_idx:02X}"
+            stem = Path(plugin_name).stem
+            out_ini = sp_dir / f"{prefix}-{stem}_SkyGen.ini"
+
+            lines = [
+                f"; Auto-generated by SkyGen (Amethyst) for {plugin_name}",
+                f"; Record types: {', '.join(sorted(sp_sigs))}",
+                f"; Edit the right-hand value of each Set<Field> line to apply your change.",
+                "; SkyPatcher filterByFormID uses full 8-char FormID (with load order).",
+                "",
+            ]
+            # Group entries by signature
+            from collections import defaultdict
+            by_sig: dict = defaultdict(list)
+            for rec in records:
+                by_sig[rec["signature"]].append(rec)
+
+            if by_sig:
+                for sig in sorted(by_sig.keys()):
+                    lines.append(f"; --- {sig} records ---")
+                    for rec in by_sig[sig]:
+                        label = rec["editor_id"] or rec["name"] or rec["local_id"]
+                        lines.append(f"; {label}")
+                        # SkyPatcher format: PluginName|FormID:operation=value
+                        # Use full 8-char FormID (with load order byte)
+                        form_id = rec["form_id"]  # Already 8-char with load order
+                        lines.append(f"filterByFormID={plugin_name}|{form_id}")
+                        # Emit a commented-out example action for the sig type
+                        example = _SP_EXAMPLE_ACTION.get(sig, "; Set<Field> = <Value>")
+                        lines.append(f"; {example}")
+                        lines.append("")
+            else:
+                # Fallback
+                for sig in sorted(sp_sigs):
+                    lines += [
+                        f"; [{sig}] — could not extract FormIDs from {plugin_name}",
+                        f"; filterByFormID={plugin_name}|<FormID>",
+                        f"; {_SP_EXAMPLE_ACTION.get(sig, 'Set<Field> = <Value>')}",
+                        "",
+                    ]
+
+            out_ini.write_text("\n".join(lines), encoding="utf-8")
+            written += 1
+            self._log_ui(f"SP: {out_ini.name} ({len(records)} records)")
+
+        self._log_ui(f"SkyPatcher done: {written} INIs written to {sp_dir}")
+        return written
+
+    # ------------------------------------------------------------------
+    # Step 3 — Done
+    # ------------------------------------------------------------------
+
+    def _show_step_done(self, mode: str, written: int, out_dir: Path) -> None:
+        """Completion summary with Open Folder button."""
+        self._clear_body()
+        if hasattr(self, "_gen_cancel_btn") and self._gen_cancel_btn:
+            try:
+                self._gen_cancel_btn.pack_forget()
+            except Exception:
+                pass
+
+        ctk.CTkLabel(
+            self._body, text="\u2705 Generation Complete",
+            font=FONT_BOLD, text_color="#6bc76b",
+        ).pack(pady=(0, 8))
+
+        ctk.CTkLabel(
+            self._body,
+            text=(
+                f"Output type:  {mode}"
+                f"\nINI files written:  {written}"
+                f"\n\nOutput mod:  {out_dir.name}"
+                f"\n{out_dir}"
+            ),
+            font=FONT_NORMAL, text_color=TEXT_DIM, justify="left", wraplength=380,
+        ).pack(pady=(0, 12))
+
+        # Open output folder
+        ctk.CTkButton(
+            self._body, text="Open output folder",
+            width=200, height=36,
+            font=FONT_BOLD,
+            fg_color=BG_HEADER, hover_color="#3d3d3d", text_color=TEXT_MAIN,
+            command=lambda: self._xdg_open(out_dir),
+        ).pack(pady=(0, 8))
+
+        # Close button
+        ctk.CTkButton(
+            self._body, text="Close", width=140, height=40,
+            font=FONT_BOLD,
+            fg_color=ACCENT, hover_color=ACCENT_HOV, text_color=TEXT_ON_ACCENT,
+            command=self._close,
+        ).pack()
+

--- a/src/wizards/skygen.py
+++ b/src/wizards/skygen.py
@@ -565,27 +565,6 @@ def _sniff_plugin(plugin_path: Path, mod_folder: Optional[Path]) -> PluginDNA:
     )
 
 
-def _find_plugin_file(plugin_name: str, mods_path: Path,
-                      data_path: Optional[Path] = None) -> Optional[Path]:
-    """Locate plugin file on disk. Checks Data/, staging mods/, and FOMOD Data/."""
-    if data_path:
-        candidate = data_path / plugin_name
-        if candidate.is_file():
-            return candidate
-    if mods_path and mods_path.is_dir():
-        try:
-            for mod_dir in mods_path.iterdir():
-                if not mod_dir.is_dir():
-                    continue
-                for sub in (mod_dir, mod_dir / "Data"):
-                    candidate = sub / plugin_name
-                    if candidate.is_file():
-                        return candidate
-        except OSError:
-            pass
-    return None
-
-
 # Path helpers
 
 def _read_active_profile(game: "BaseGame") -> str:
@@ -877,11 +856,8 @@ class SkyGenWizard(ctk.CTkFrame):
 
     @staticmethod
     def _xdg_open(path: Path) -> None:
-        import subprocess
-        try:
-            subprocess.Popen(["xdg-open", str(path)])
-        except Exception:
-            pass
+        from Utils.xdg import xdg_open
+        xdg_open(path)
 
     # ------------------------------------------------------------------
     # Step 1 — Scan
@@ -923,9 +899,10 @@ class SkyGenWizard(ctk.CTkFrame):
 
         btn_row = ctk.CTkFrame(self._body, fg_color="transparent")
         btn_row.pack(side="bottom", pady=(8, 0))
+        self._scan_btn_row = btn_row
 
         ctk.CTkButton(
-            btn_row, text="Cancel", width=100, height=36,
+            btn_row, text="Close", width=100, height=36,
             font=FONT_BOLD,
             fg_color=BG_HEADER, hover_color="#3d3d3d", text_color=TEXT_MAIN,
             command=self._close,
@@ -948,12 +925,13 @@ class SkyGenWizard(ctk.CTkFrame):
         # Show a Cancel button
         if self._scan_cancel_btn is None:
             self._scan_cancel_btn = ctk.CTkButton(
-                self._body, text="Cancel", width=100, height=36,
+                self._scan_btn_row, text="Cancel", width=100, height=36,
                 font=FONT_BOLD, fg_color=BG_HEADER, hover_color="#3d3d3d",
                 text_color=TEXT_MAIN, command=self._cancel,
             )
             self._scan_cancel_btn.pack(before=self._scan_btn, side="right", padx=(0, 8))
-        self._scan_cancel_btn.pack(before=self._scan_btn, side="right", padx=(0, 8))
+        else:
+            self._scan_cancel_btn.pack(before=self._scan_btn, side="right", padx=(0, 8))
         threading.Thread(target=self._do_scan, daemon=True).start()
 
     def _cancel(self):
@@ -1182,8 +1160,10 @@ class SkyGenWizard(ctk.CTkFrame):
         # Generate button
         btn_row = ctk.CTkFrame(self._body, fg_color="transparent")
         btn_row.pack(side="bottom", pady=(8, 0))
+        self._gen_btn_row = btn_row
+
         ctk.CTkButton(
-            btn_row, text="\u2190 Back", width=100, height=36,
+            btn_row, text="Back", width=100, height=36,
             font=FONT_BOLD,
             fg_color=BG_HEADER, hover_color="#3d3d3d", text_color=TEXT_MAIN,
             command=self._show_step_scan,
@@ -1258,11 +1238,13 @@ class SkyGenWizard(ctk.CTkFrame):
         # Show a Cancel button
         if not hasattr(self, "_gen_cancel_btn") or self._gen_cancel_btn is None:
             self._gen_cancel_btn = ctk.CTkButton(
-                self._body, text="Cancel", width=100, height=36,
+                self._gen_btn_row, text="Cancel", width=100, height=36,
                 font=FONT_BOLD, fg_color=BG_HEADER, hover_color="#3d3d3d",
                 text_color=TEXT_MAIN, command=self._cancel,
             )
-        self._gen_cancel_btn.pack(side="right", padx=(0, 8), before=self._gen_btn)
+            self._gen_cancel_btn.pack(side="right", padx=(0, 8), before=self._gen_btn)
+        else:
+            self._gen_cancel_btn.pack(side="right", padx=(0, 8), before=self._gen_btn)
         threading.Thread(target=self._do_generate, daemon=True).start()
 
     def _do_generate(self):
@@ -1333,7 +1315,7 @@ class SkyGenWizard(ctk.CTkFrame):
         except Exception:
             pass
 
-    def _gen_bos(self, out_dir: Path) -> None:
+    def _gen_bos(self, out_dir: Path) -> int:
         """Write BOS swap INIs using object names (EditorIDs).
 
         Format: sourceObject|replacementObject|NONE|chanceR(percent)


### PR DESCRIPTION
Plugin Audit & Cleanup wizard + SkyGen improvements + BOS/SP badge in plugin panel.  Saw the mod on the nexus but the mod author only made it mo2 compatible.  Instead of running it externally, it makes more sense to integrate it via the wizards.. he did all the hard work already though.

1. Adds a SkyGen wizard that automatically generates Base Object Swapper and SkyPatcher INI patch files for your installed mods — scanning your Amethyst staging directory, resolving plugin relationships, and writing ready-to-use INIs into dedicated SkyGen output folders as mods. Excludes Bashed Patch masters.

2. Adds a Plugin Audit & Cleanup wizard that scans your load order for BOS/Skypatcher patched plugins, identifies which can be safely disabled (no new records, no dependent masters), and allows bulk-cleans orphaned SkyGen BOS/SkyPatcher INIs from output directories — never touching original mod INIs.

3. Adds BOS/SP badges (B, S, B+S) to the plugin panel for plugins that have Base Object Swapper or SkyPatcher patches in your staging mods, scanned in the background on load.

I expect that people will generate BOS/SP inis for mods they can't really remove the plugin for, so i added that plugin audit wizard.  We could just prevent them from being able to select it in the first place, but there is apparently a use case where if you want to have guaranteed load order.