### PR TITLE
Remove the webbrowser component in favor of Utils.xdg.open_url

### DIFF
--- a/src/gui/collections_dialog.py
+++ b/src/gui/collections_dialog.py
@@ -16,7 +16,6 @@ import threading
 import tkinter as tk
 import tkinter.messagebox
 import tkinter.ttk as ttk
-import webbrowser
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -6582,7 +6581,7 @@ class CollectionDetailDialog(tk.Frame):
         url = f"https://www.nexusmods.com/games/{self._game_domain}/collections/{slug}"
         if self._revision_number:
             url += f"/revisions/{self._revision_number}"
-        webbrowser.open(url)
+        open_url(url)
 
     def _on_open_missing_on_nexus(self):
         """Open Nexus pages for all mods in the collection that are not installed."""

--- a/src/gui/dialogs.py
+++ b/src/gui/dialogs.py
@@ -15,7 +15,6 @@ import threading
 import tkinter as tk
 import tkinter.messagebox
 import tkinter.ttk as ttk
-import webbrowser
 from pathlib import Path
 from types import SimpleNamespace
 

--- a/src/gui/plugin_panel.py
+++ b/src/gui/plugin_panel.py
@@ -10,7 +10,6 @@ import re
 import subprocess
 import threading
 import tkinter as tk
-import webbrowser
 import tkinter.ttk as ttk
 from pathlib import Path
 
@@ -4871,7 +4870,7 @@ class PluginPanel(PluginPanelExeLauncherMixin, PluginPanelLOOTMixin,
                     continue
                 label_name = loc.get("name") or url
                 items.append((f"Open: {label_name}",
-                               lambda u=url: webbrowser.open(u)))
+                               lambda u=url: open_url(u)))
         else:
             items.append((f"Enable selected ({count})",
                            lambda idxs=toggleable: self._enable_selected_plugins(idxs)))

--- a/src/gui/status_bar.py
+++ b/src/gui/status_bar.py
@@ -7,7 +7,6 @@ import os
 import subprocess
 import sys
 import threading
-import webbrowser
 import tkinter as tk
 import customtkinter as ctk
 
@@ -20,7 +19,7 @@ from Utils.config_paths import (
     get_profiles_dir,
     get_config_dir,
 )
-from Utils.xdg import xdg_open
+from Utils.xdg import open_url, xdg_open
 from Utils.ui_config import (
     load_ui_scale, save_ui_scale, detect_hidpi_scale,
     load_collection_settings, save_collection_settings,
@@ -234,14 +233,14 @@ class StatusBar(ctk.CTkFrame):
             label_bar, text="Ko-Fi", width=55, height=16,
             fg_color="#7b2d8b", hover_color="#9a3aae",
             text_color="#ffffff", font=FONT_SMALL,
-            command=lambda: webbrowser.open("https://ko-fi.com/chrisdkn"),
+            command=lambda: open_url("https://ko-fi.com/chrisdkn"),
         ).pack(side="right", padx=(0, 2), pady=2)
 
         ctk.CTkButton(
             label_bar, text="Github", width=60, height=16,
             fg_color="#24292e", hover_color="#3a3f44",
             text_color="#ffffff", font=FONT_SMALL,
-            command=lambda: webbrowser.open("https://github.com/ChrisDKN/Amethyst-Mod-Manager"),
+            command=lambda: open_url("https://github.com/ChrisDKN/Amethyst-Mod-Manager"),
         ).pack(side="right", padx=(0, 2), pady=2)
 
         ctk.CTkButton(
@@ -370,7 +369,7 @@ class StatusBar(ctk.CTkFrame):
         app = self.winfo_toplevel()
         api = getattr(app, "_nexus_api", None)
         if api is None:
-            webbrowser.open(_AMM_URL)
+            open_url(_AMM_URL)
             return
 
         def _notify(state, message):


### PR DESCRIPTION
This PR replaces all uses of the python `webbrowser` component with the function `Utils.xdg.open_url`, which respects the XDG settings.

This fixes https://github.com/ChrisDKN/Amethyst-Mod-Manager/issues/189.

Reasoning for applying this change to the entire GUI-codebase, being that it makes the codebase more consistent, since sometimes it used `webbrowser.open()`, and sometimes `open_url`.