### PR TITLE
fix: CTKScrollableFrame targeting only older versions of customtkinter

### DIFF
--- a/src/gui/modlist_filter_panel.py
+++ b/src/gui/modlist_filter_panel.py
@@ -191,7 +191,8 @@ class ModListFilterPanelMixin:
             import sys as _sys
 
             def _slow_mouse_wheel_all(self_sf, event, _step=step):
-                if not self_sf.check_if_master_is_canvas(event.widget):
+                check_fn = getattr(self_sf, "_check_if_valid_scroll", None) or getattr(self_sf, "check_if_master_is_canvas", None)
+                if check_fn and not check_fn(event.widget):
                     return
                 delta = getattr(event, "delta", 0) or 0
                 if delta == 0:

--- a/src/gui/wheel_compat.py
+++ b/src/gui/wheel_compat.py
@@ -129,7 +129,8 @@ def patch_ctk_scrollable_frame() -> None:
         return
 
     def _patched_mouse_wheel_all(self, event):
-        if not self.check_if_master_is_canvas(event.widget):
+        check_fn = getattr(self, "_check_if_valid_scroll", None) or getattr(self, "check_if_master_is_canvas", None)
+        if check_fn and not check_fn(event.widget):
             return
         delta = getattr(event, "delta", 0) or 0
         if delta == 0:


### PR DESCRIPTION
# Fix: CTKScrollableFrame targeting only older versions of customtkinter

## Problem
In some versions of `customtkinter` (such as the version installed in specific python environment, e.g., `6.0.0`), the internal method `check_if_master_is_canvas` in `CTkScrollableFrame` is not present, or has been replaced by `_check_if_valid_scroll`. This causes an `AttributeError` when scrolling the modlist with the mouse wheel on platforms running these versions.

## Solution
Use `getattr` to dynamically resolve the verification method, falling back to `_check_if_valid_scroll` or `check_if_master_is_canvas` depending on what the installed version of `customtkinter` provides. This ensures backward and forward compatibility across different `customtkinter` releases.

## Changes

### `src/gui/wheel_compat.py`
```diff
     def _patched_mouse_wheel_all(self, event):
-        if not self.check_if_master_is_canvas(event.widget):
+        check_fn = getattr(self, "_check_if_valid_scroll", None) or getattr(self, "check_if_master_is_canvas", None)
+        if check_fn and not check_fn(event.widget):
             return
```

### `src/gui/modlist_filter_panel.py`
```diff
             def _slow_mouse_wheel_all(self_sf, event, _step=step):
-                if not self_sf.check_if_master_is_canvas(event.widget):
+                check_fn = getattr(self_sf, "_check_if_valid_scroll", None) or getattr(self_sf, "check_if_master_is_canvas", None)
+                if check_fn and not check_fn(event.widget):
                     return
```

## References
- [CustomTkinter GitHub Repository - ctk_scrollable_frame.py](https://github.com/TomSchimansky/CustomTkinter/blob/master/customtkinter/windows/widgets/ctk_scrollable_frame.py)
