### PR TITLE
Add fail-safe exit to cd in run_qt.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ decky/
 .mcp.json
 **/__pycache__/
 /tools
+AmethystModManager-AppImage/
+*.AppImage.zsync
+src/appimage/dist/

--- a/src/run_qt.sh
+++ b/src/run_qt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit 1
 
 # Drop AppImage-injected env that poisons a from-source run. If the user
 # launched a terminal from a running AppImage at any point, these inherit


### PR DESCRIPTION
Adds '|| exit 1' after cd in run_qt.sh (ShellCheck SC2164). Without it, a failed cd silently continues execution from the wrong directory instead of aborting.