### PR TITLE
Fix Amethyst app tray icon not showing

### DIFF
--- a/src/gui_qt/app.py
+++ b/src/gui_qt/app.py
@@ -12868,7 +12868,8 @@ def _apply_app_identity(app) -> None:
         app.setDesktopFileName("io.github.Amethyst.ModManager")
     elif os.environ.get("APPDIR") or os.environ.get("APPIMAGE"):
         app.setDesktopFileName("amethyst-mod-manager")
-
+    else:
+        app.setDesktopFileName("io.github.Amethyst.ModManager")
 
 def run() -> int:
     import sys


### PR DESCRIPTION
Not sure if this is the case for others, but for me the icon for Amethyst was a gear icon. This fix just makes sure that the actual App icon shows in the App tray. 

## Before
<img width="454" height="75" alt="Screenshot_2026-07-21_11-22-52" src="https://github.com/user-attachments/assets/7b0d5ad6-1a5e-48e0-80be-6f73d262ccec" />

## After
<img width="454" height="75" alt="Screenshot_2026-07-21_11-23-47" src="https://github.com/user-attachments/assets/a8c7d75e-3559-455b-b3e9-d72370297c59" />


### Sys Specs
- Distro: Arch
- Cosmic DE
