### PR TITLE
Per-mod reorder lock, separator copy/move to profile, and priority-order/share-code fixes

### DIFF
--- a/.claude/rules/release-cicd.md
+++ b/.claude/rules/release-cicd.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - ".github/workflows/*.yml"
+  - "Changelog.txt"
+---
+
+# Release & CI/CD conventions
+
+- Three workflows: `test-build.yml`, `build.yml`, `release.yml`. Don't consolidate them without checking why they were split.
+- `release.yml` triggers on `v*` tags.
+- Changelog extraction parses `- v{major.minor.patch}` headers exactly — any deviation (extra text on the header line, different bullet/heading style) breaks the release notes extraction. Verify a new header matches this format before committing.
+- Fork's version always wins over upstream on conflict (e.g. `2.0.4-beta.X` beats `2.0.3-beta.X`) — don't "fix" a version bump downward to match upstream.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Amethyst Mod Manager — Fork (BG3 modding focus)
+
+## Project context
+- Personal fork of TheMrGeeBee/Amethyst-Mod-Manager (upstream: ChrisDKN's Amethyst Mod Manager, GPL-3)
+- Focus: Baldur's Gate 3 modding support
+- Upstream remote is tracked separately from origin; upstream maintainer communication has historically been difficult — do not assume upstream will merge quickly or engage constructively
+
+## Version & sync rules
+- Fork's version always wins over upstream on conflict (e.g. `2.0.4-beta.X` beats `2.0.3-beta.X`)
+- Use `sync-upstream.sh` (repo root) for upstream merges — it has an explicit confirmation gate before touching `upstream/Testing`. Never bypass that gate.
+- Before opening a PR upstream, create a clean branch — branch contamination from other work has previously forced a close/recreate (see PR #264 history)
+
+## CI/CD
+- Three workflows: `test-build.yml`, `build.yml`, `release.yml`
+- Release pipeline triggers on `v*` tags
+- Changelog extraction looks for `- v{major.minor.patch}` headers — keep that format exact
+
+## Known-good recovery paths
+- If a broad automated tool (e.g. `ruff --fix`) or `git restore .` clobbers uncommitted work, VSCodium Local History has recovered it before — check there first, don't panic-recreate
+
+## Conventions
+- Follow existing patterns in the codebase before introducing new ones
+- Prefer clean, maintainable code over clever solutions
+- Recently touched for code quality: `ue5_game.py`, `nexus_requirements.py`, `ba2_writer.py`
+
+## Gotchas
+- Collection install metadata (uploader, category, endorsement) is populated via a background GraphQL fetch during install, reconciled in a Step 5 pass — don't assume it's synchronous

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -2,9 +2,13 @@
 ### Additions
 - Added a per-mod reorder lock: locked mods can't be dragged, sorted, moved to a separator, removed, or moved to another profile until unlocked (rename and notes remain available). "Set priority…" shows greyed out while locked
 - Added the ability to copy or move separators (name, colour, lock state) to another profile, preserving their relative order
+- Added a dedicated "Locked" column for the per-mod reorder lock (click to toggle), hidden by default but automatically shown when a loaded profile actually has a locked mod, so shared/imported profiles surface their locks
+### Changes
+- Fixed the "Show / hide columns" tooltip capitalisation to "Show / Hide columns"
 ### Bug Fixes
 - Fixed mods not retaining their priority order when copied or moved to another profile while the modlist was sorted by a column or in reverse-priority view
 - Fixed separator colour/lock/collapsed state not being fully cleaned up when a separator was removed
+- Fixed mod and separator reorder-lock state being silently dropped from share-code (AMMCODE1) exports and imports
 
 ---
 

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,9 @@
+- v2.0.6
+### Bug Fixes
+- Fixed mods not retaining their priority order when copied or moved to another profile while the modlist was sorted by a column or in reverse-priority view
+
+---
+
 - v2.0.4
 ### Additions
 - Added the option to change download speed limits

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,10 @@
 - v2.0.6
+### Additions
+- Added a per-mod reorder lock: locked mods can't be dragged, sorted, moved to a separator, removed, or moved to another profile until unlocked (rename and notes remain available). "Set priority…" shows greyed out while locked
+- Added the ability to copy or move separators (name, colour, lock state) to another profile, preserving their relative order
 ### Bug Fixes
 - Fixed mods not retaining their priority order when copied or moved to another profile while the modlist was sorted by a column or in reverse-priority view
+- Fixed separator colour/lock/collapsed state not being fully cleaned up when a separator was removed
 
 ---
 

--- a/src/Utils/collection_install.py
+++ b/src/Utils/collection_install.py
@@ -1423,6 +1423,12 @@ def run_collection_install(
         except Exception as exc:
             log(f"Collection install: apply disabled states failed: {exc}")
         try:
+            _apply_schema_locked_mods(
+                modlist_path, collection_schema, schema_file_id_to_pos,
+                install_order, profile_dir, log)
+        except Exception as exc:
+            log(f"Collection install: apply mod locks failed: {exc}")
+        try:
             _apply_manifest_separators(
                 profile_dir, modlist_path, collection_schema, log)
         except Exception as exc:
@@ -1714,6 +1720,54 @@ def _apply_schema_disabled_mods(modlist_path, collection_schema,
             f"(manifest enabled=false).")
 
 
+def _apply_schema_locked_mods(modlist_path, collection_schema,
+                              schema_file_id_to_pos, install_order,
+                              profile_dir, log):
+    """Reorder-lock the mods the manifest carries as ``locked: true`` (share-
+    code exports include the source profile's per-mod reorder locks — see
+    ``profile_export.load_rows`` — so the recipient understands why those
+    mods won't reorder). Resolution mirrors ``_apply_schema_disabled_mods``
+    (install_order key, falling back to a name match). Unlike enabled/
+    disabled, the lock isn't a modlist.txt prefix — it's written into the
+    target profile's ``mod_locks`` (Utils.profile_state), same as a manual
+    Lock mod would."""
+    schema_mods: list[dict] = collection_schema.get("mods", [])
+    key_to_folder: dict[int, str] = {key: folder for key, folder in install_order}
+    targets: set[str] = set()
+    for m in schema_mods:
+        if not m.get("locked"):
+            continue
+        folder = ""
+        fid = (m.get("source") or {}).get("fileId")
+        if fid is not None:
+            try:
+                folder = key_to_folder.get(
+                    schema_file_id_to_pos.get(int(fid), -1), "")
+            except (TypeError, ValueError):
+                folder = ""
+        if not folder:
+            folder = m.get("name") or ""
+        if folder:
+            targets.add(folder.lower())
+    if not targets:
+        return
+    entries = read_modlist(modlist_path)
+    locked_names = [e.name for e in entries
+                   if not e.is_separator and e.name.lower() in targets]
+    if not locked_names:
+        return
+    try:
+        from Utils.profile_state import read_mod_locks, write_mod_locks
+        locks = read_mod_locks(profile_dir)
+        for name in locked_names:
+            locks[name] = True
+        write_mod_locks(profile_dir, locks)
+        log(f"Collection install: reorder-locked {len(locked_names)} mod(s) "
+            f"(manifest locked=true).")
+    except Exception as exc:
+        log(f"Collection install: apply mod locks failed: {exc}")
+
+
 def _apply_manifest_separators(profile_dir, modlist_path, collection_schema, log):
     """Re-insert the source modlist's separators from the manifest's
     ``modlistSeparators`` block (share-code exports; see
@@ -1750,7 +1804,12 @@ def _apply_manifest_separators(profile_dir, modlist_path, collection_schema, log
         if sep.get("color"):
             colors[name] = str(sep["color"])
         if sep.get("locked"):
-            locks[name] = True
+            # separator_colors is keyed by the internal (`..._separator`) name
+            # but separator_locks is keyed by the DISPLAY name (see
+            # ModlistModel.is_sep_locked/toggle_sep_lock) — writing under the
+            # internal name here means the UI never reads it back as locked.
+            display_name = name[:-len("_separator")] if name.endswith("_separator") else name
+            locks[display_name] = True
     if not added:
         return
     write_modlist(modlist_path, entries)

--- a/src/Utils/mod_rename.py
+++ b/src/Utils/mod_rename.py
@@ -17,6 +17,7 @@ from Utils.profile_state import (
     read_disabled_plugins, write_disabled_plugins,
     read_excluded_mod_files, write_excluded_mod_files,
     read_mod_notes, write_mod_notes,
+    read_mod_locks, write_mod_locks,
 )
 
 
@@ -31,7 +32,8 @@ def migrate_mod_state(profile_dir: Path | None, old_name: str,
             (read_mod_strip_prefixes, write_mod_strip_prefixes, "strip prefixes"),
             (read_disabled_plugins, write_disabled_plugins, "disabled plugins"),
             (read_excluded_mod_files, write_excluded_mod_files, "excluded files"),
-            (read_mod_notes, write_mod_notes, "mod notes")):
+            (read_mod_notes, write_mod_notes, "mod notes"),
+            (read_mod_locks, write_mod_locks, "mod lock state")):
         try:
             data = reader(profile_dir)
             if old_name in data:

--- a/src/Utils/profile_export.py
+++ b/src/Utils/profile_export.py
@@ -29,6 +29,7 @@ A *row* is a plain dict describing one mod's export configuration::
         "size_bytes":    int,   # original archive size from meta.ini (0 if unknown)
         "root_folder":   bool,  # deploys to game root (meta.ini rootFolder)
         "enabled":       bool,  # modlist enabled state of the source entry
+        "locked":        bool,  # reorder-locked (Utils.profile_state mod_locks)
         "source":        str,   # "nexus" | "direct" | "bundle" | "ignore"
         "direct_url":    str,
     }
@@ -61,6 +62,13 @@ def load_rows(entries, game) -> list[dict]:
 
     staging_root = game.get_effective_mod_staging_path() if game else None
     profile_dir = getattr(game, "_active_profile_dir", None) if game else None
+    mod_locks: dict = {}
+    if profile_dir:
+        try:
+            from Utils.profile_state import read_mod_locks
+            mod_locks = read_mod_locks(Path(profile_dir))
+        except Exception:
+            pass
 
     rows: list[dict] = []
     for entry in entries:
@@ -122,6 +130,7 @@ def load_rows(entries, game) -> list[dict]:
             "size_bytes":       size_bytes,
             "root_folder":      root_folder,
             "enabled":          bool(getattr(entry, "enabled", True)),
+            "locked":           bool(mod_locks.get(name)),
             "source":           "nexus",
             "direct_url":       "",
         })
@@ -257,6 +266,9 @@ def build_manifest(rows, game_domain: str, app_version: str, *,
         # importer stages the mod normally, then marks it disabled.
         if row.get("enabled") is False:
             mod_entry["enabled"] = False
+        # Carry the reorder-lock (unlocked mods stay implicit, like enabled).
+        if row.get("locked"):
+            mod_entry["locked"] = True
         # Root-deploy mods use the Nexus-collections "dinput" install type —
         # the importer already maps details.type == "dinput" to meta rootFolder.
         if row.get("root_folder"):
@@ -649,7 +661,13 @@ def _separator_blocks(entries, kept_names: set, profile_dir) -> list[dict]:
             current = {"name": name, "mods": []}
             if colors.get(name):
                 current["color"] = colors[name]
-            if locks.get(name):
+            # separator_colors is keyed by the internal (`..._separator`) name
+            # but separator_locks is keyed by the DISPLAY name (see
+            # ModlistModel.is_sep_locked/toggle_sep_lock) — strip the suffix
+            # before the lock lookup or a locked separator silently exports
+            # as unlocked.
+            display_name = getattr(entry, "display_name", None) or name
+            if locks.get(display_name):
                 current["locked"] = True
             blocks.append(current)
         elif current is not None and name in kept_names:

--- a/src/Utils/profile_state.py
+++ b/src/Utils/profile_state.py
@@ -15,6 +15,7 @@ consolidates all small per-profile JSON/text state files:
   profile_settings            dict  (profile_specific_mods, collection_url, original_default, …)
   ignored_missing_requirements list[str]
   custom_exes                 list[str]  (per-profile Run-menu exe paths)
+  mod_locks                   dict[str, bool]  (mod_name -> reorder-locked)
 
 Migration: when profile_state.json is missing but legacy per-key files exist,
 read_profile_state() merges them into a new profile_state.json and deletes those
@@ -194,6 +195,13 @@ def read_collapsed_seps(profile_dir: Path, state: dict | None = None) -> set[str
 
 def read_separator_locks(profile_dir: Path, state: dict | None = None) -> dict:
     raw = _read_key(profile_dir, state, "separator_locks")
+    if isinstance(raw, dict):
+        return raw
+    return {}
+
+
+def read_mod_locks(profile_dir: Path, state: dict | None = None) -> dict:
+    raw = _read_key(profile_dir, state, "mod_locks")
     if isinstance(raw, dict):
         return raw
     return {}
@@ -380,6 +388,10 @@ def write_collapsed_seps(profile_dir: Path, value: set[str]) -> None:
 
 def write_separator_locks(profile_dir: Path, value: dict) -> None:
     _update_key(profile_dir, "separator_locks", value)
+
+
+def write_mod_locks(profile_dir: Path, value: dict) -> None:
+    _update_key(profile_dir, "mod_locks", value)
 
 
 def write_separator_colors(profile_dir: Path, value: dict) -> None:

--- a/src/Utils/separator_copy.py
+++ b/src/Utils/separator_copy.py
@@ -1,0 +1,74 @@
+"""Copy / move a separator (marker only — name, color, lock state) to another
+profile — tkinter-free. Companion to ``mod_copy.py``, but separators have no
+on-disk folder, so this is purely a modlist.txt + profile_state.json edit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from Utils.modlist import ModEntry, _SEPARATOR_SUFFIX, read_modlist, write_modlist
+
+
+def separator_exists_in_profile(target_modlist_path: Path, name: str) -> bool:
+    """True if a separator named *name* (internal, with suffix) already
+    exists in *target_modlist_path*."""
+    try:
+        entries = read_modlist(target_modlist_path) if target_modlist_path.exists() else []
+    except Exception:
+        entries = []
+    return any(e.is_separator and e.name == name for e in entries)
+
+
+def register_separators_in_modlist(target_modlist_path: Path,
+                                   target_profile_dir: Path,
+                                   separators: "list[dict]") -> "list[str]":
+    """Prepend *separators* — ordered highest-priority-first — to the target
+    modlist.txt as a single block (dedup by internal name, skip existing),
+    mirroring ``mod_copy.register_mods_in_modlist``. Each dict is
+    ``{"name": internal-name-with-suffix, "color": str|None, "locked": bool}``.
+    Also writes the color (keyed by internal name) and lock (keyed by display
+    name) into the target profile's profile_state.json. Returns the internal
+    names actually inserted."""
+    try:
+        entries = read_modlist(target_modlist_path) if target_modlist_path.exists() else []
+    except Exception:
+        entries = []
+    existing = {e.name for e in entries if e.is_separator}
+    new_entries: list[ModEntry] = []
+    added: list[str] = []
+    for sep in separators:
+        name = sep["name"]
+        if name in existing:
+            continue
+        new_entries.append(ModEntry(name=name, enabled=True, locked=True,
+                                    is_separator=True))
+        added.append(name)
+    if new_entries:
+        write_modlist(target_modlist_path, new_entries + entries)
+        _write_separator_extras(target_profile_dir, separators, added)
+    return added
+
+
+def _write_separator_extras(target_profile_dir: Path, separators: "list[dict]",
+                            added_names: "list[str]") -> None:
+    from Utils.profile_state import (
+        read_separator_colors, write_separator_colors,
+        read_separator_locks, write_separator_locks)
+    by_name = {s["name"]: s for s in separators}
+    colors = read_separator_colors(target_profile_dir)
+    locks = read_separator_locks(target_profile_dir)
+    changed_colors = changed_locks = False
+    for name in added_names:
+        sep = by_name.get(name) or {}
+        if sep.get("color"):
+            colors[name] = sep["color"]
+            changed_colors = True
+        if sep.get("locked"):
+            display = (name[:-len(_SEPARATOR_SUFFIX)]
+                      if name.endswith(_SEPARATOR_SUFFIX) else name)
+            locks[display] = True
+            changed_locks = True
+    if changed_colors:
+        write_separator_colors(target_profile_dir, colors)
+    if changed_locks:
+        write_separator_locks(target_profile_dir, locks)

--- a/src/gui_qt/app.py
+++ b/src/gui_qt/app.py
@@ -5513,26 +5513,47 @@ class MainWindow(QMainWindow):
         self._modlist_view.viewport().update()
 
     def _on_separators_removed(self, names):
-        """Drop stored colour + deploy override for removed separators."""
+        """Drop stored colour + deploy override + lock + collapsed state for
+        removed separators."""
+        from Utils.modlist import _SEPARATOR_SUFFIX
         profile_dir = self._gs.profile_dir()
+        display_names = set()
         for nm in names:
             self._modlist_model.set_sep_color(nm, None)
             self._modlist_model.set_sep_deploy_info(nm, None)
+            disp = nm[:-len(_SEPARATOR_SUFFIX)] if nm.endswith(_SEPARATOR_SUFFIX) else nm
+            display_names.add(disp)
+            self._modlist_model._sep_locks.pop(disp, None)
+            self._modlist_model._collapsed.discard(disp)
         if profile_dir is not None:
             try:
                 from Utils.profile_state import (
                     read_separator_colors, write_separator_colors,
-                    read_separator_deploy_paths, write_separator_deploy_paths)
+                    read_separator_deploy_paths, write_separator_deploy_paths,
+                    read_separator_locks, write_separator_locks,
+                    read_collapsed_seps, write_collapsed_seps)
                 colors = read_separator_colors(profile_dir)
                 paths = read_separator_deploy_paths(profile_dir)
-                changed_c = changed_p = False
+                locks = read_separator_locks(profile_dir)
+                collapsed = read_collapsed_seps(profile_dir)
+                changed_c = changed_p = changed_l = changed_col = False
                 for nm in names:
                     changed_c |= colors.pop(nm, None) is not None
                     changed_p |= paths.pop(nm, None) is not None
+                for disp in display_names:
+                    if locks.pop(disp, None) is not None:
+                        changed_l = True
+                    if disp in collapsed:
+                        collapsed.discard(disp)
+                        changed_col = True
                 if changed_c:
                     write_separator_colors(profile_dir, colors)
                 if changed_p:
                     write_separator_deploy_paths(profile_dir, paths)
+                if changed_l:
+                    write_separator_locks(profile_dir, locks)
+                if changed_col:
+                    write_collapsed_seps(profile_dir, collapsed)
             except Exception as exc:
                 print(f"[gui_qt] separator removal cleanup failed: {exc}",
                       flush=True)
@@ -6081,6 +6102,56 @@ class MainWindow(QMainWindow):
                 model.save()  # single save → one filemap rebuild for the batch
         if payload.get("removed"):
             self._reload_modlist()
+
+    def _copy_separators_to_profile(self, sep_names, sep_rows, target_profile, move):
+        """Copy (or move) the given separators — marker only (name, color,
+        lock) — into *target_profile*. Synchronous: separators are small
+        JSON/text writes, no worker thread or collision overlay needed;
+        colliding names are skipped (dedup by name)."""
+        from Utils import separator_copy
+        from Utils.modlist import _SEPARATOR_SUFFIX
+        game = self._gs.game
+        src_profile_dir = self._gs.profile_dir()
+        if game is None or src_profile_dir is None:
+            return
+        model = self._modlist_model
+        sep_names = [n for n in sep_names if n]
+        if not sep_names:
+            return
+        payload = []
+        for name in sep_names:
+            display = (name[:-len(_SEPARATOR_SUFFIX)]
+                      if name.endswith(_SEPARATOR_SUFFIX) else name)
+            payload.append({"name": name,
+                            "color": model.sep_color(name),
+                            "locked": model.is_sep_locked(display)})
+        try:
+            target_profile_dir = game.get_profile_root() / "profiles" / target_profile
+            target_modlist = target_profile_dir / "modlist.txt"
+        except Exception as exc:
+            self._notify(self.tr("Could not resolve target profile: {0}").format(exc), "error")
+            return
+        added = separator_copy.register_separators_in_modlist(
+            target_modlist, target_profile_dir, payload)
+        skipped = len(payload) - len(added)
+        if move and added:
+            from gui_qt.modlist_menu import _remove_separator_rows
+            rows = [r for r in sep_rows
+                    if (e := model.entry(r)) is not None
+                    and e.is_separator and e.name in added]
+            removed = _remove_separator_rows(self._modlist_view, model, rows)
+            if removed:
+                self._on_separators_removed(removed)
+        if added:
+            msg = ((self.tr("Moved {0} separator(s) to '{1}'.") if move
+                   else self.tr("Copied {0} separator(s) to '{1}'."))
+                  .format(len(added), target_profile))
+            if skipped:
+                msg += " " + self.tr("({0} already existed there and were skipped.)").format(skipped)
+            self._notify(msg, "success")
+        else:
+            self._notify(self.tr("All selected separator(s) already exist in '{0}'.")
+                         .format(target_profile), "info")
 
     # ---- install a Nexus mod by id (used by Missing Requirements cards) ----
     # Mirrors the Nexus browser's install flow: premium check → fetch files →
@@ -10490,6 +10561,7 @@ class MainWindow(QMainWindow):
         self._modlist_view.on_notes_changed = self._refresh_modlist_flags
         # Copy/Move to profile: worker copy + collision overlay + (move) remove.
         self._modlist_view.on_copy_to_profile = self._copy_mods_to_profile
+        self._modlist_view.on_copy_separators_to_profile = self._copy_separators_to_profile
         # Rename (context menu): folder + modindex + per-mod state migration.
         self._modlist_view.on_rename_mod = self._rename_mod_on_disk
         # Separator settings (colour + deploy override): open the scoped tab;
@@ -10507,6 +10579,7 @@ class MainWindow(QMainWindow):
             self._apply_modlist_sizes()
         with span("reload_modlist.load_separator_state"):
             self._modlist_view.load_separator_state()
+        self._modlist_view.load_mod_lock_state()
         # Point the Mod Files tab at this game/profile (index next to filemap).
         if hasattr(self, "_mod_files_view"):
             idx = (staging.parent / "modindex.bin") if staging is not None else None

--- a/src/gui_qt/modlist_delegate.py
+++ b/src/gui_qt/modlist_delegate.py
@@ -18,7 +18,7 @@ from gui_qt.theme_qt import active_palette, _c, qc, qc_contrast
 from gui_qt.icons import icon
 from gui_qt.modlist_model import (
     EntryRole, ConflictRole, BsaConflictRole, FlagsRole, HighlightRole,
-    COL_NAME, COL_FLAGS, COL_CONFLICTS,
+    COL_NAME, COL_FLAGS, COL_CONFLICTS, COL_LOCKED,
 )
 from gui_qt.modlist_data import (
     FLAG_UPDATE, FLAG_ENDORSED, FLAG_ROOT, FLAG_MODIFIED_MF, FLAG_MISSING_REQS,
@@ -284,6 +284,9 @@ class ModRowDelegate(QStyledItemDelegate):
         elif index.column() == COL_CONFLICTS:
             self._paint_conflicts(p, r, index.data(ConflictRole) or 0,
                                   index.data(BsaConflictRole) or 0)
+        elif index.column() == COL_LOCKED:
+            if not e.is_separator:
+                self._paint_locked_col(p, r, index.model().is_mod_locked(e.name))
         else:
             # Plain columns (Installed/Version/Priority): centred to match the
             # centred headers + the icon columns.
@@ -308,6 +311,27 @@ class ModRowDelegate(QStyledItemDelegate):
         y = r.top() + (r.height() - self.LOCK_SZ) // 2
         return QRect(r.right() - self.PAD - self.LOCK_SZ, y,
                      self.LOCK_SZ, self.LOCK_SZ)
+
+    def _lock_col_rect(self, r):
+        """Centred lock-box rect for the dedicated Locked column (mod rows) —
+        same size/style as _lock_rect, just centred in the cell instead of
+        pinned to its right edge, matching the Flags/Conflicts icon columns."""
+        sz = self.LOCK_SZ
+        return QRect(r.left() + (r.width() - sz) // 2,
+                    r.top() + (r.height() - sz) // 2, sz, sz)
+
+    def _paint_locked_col(self, p, r, locked):
+        """Locked column cell: empty box when unlocked, (gold) lock.png on a
+        neutral fill when locked — same visual language as the separator/
+        Name-column lock boxes. Click handling in editorEvent()."""
+        box = self._lock_col_rect(r)
+        p.setPen(QPen(self.c_border, 1))
+        p.setBrush(QBrush(self.c_check_off))
+        p.drawRoundedRect(box, 3, 3)
+        if locked:
+            lico = icon("lock.png", self.LOCK_SZ - 2)
+            if not lico.isNull():
+                lico.paint(p, box.adjusted(1, 1, -1, -1))
 
     def _col_rect(self, col, r):
         """Sub-rect of a (full-width, spanned) separator row aligned with a
@@ -474,20 +498,14 @@ class ModRowDelegate(QStyledItemDelegate):
 
         tx = box.right() + 10
 
-        # Lock glyph — MO2 "always-on" flag (emoji).
+        # Lock glyph — MO2 "always-on" flag (emoji). The independent reorder-
+        # lock flag has its own dedicated Locked column (see _paint_locked_col)
+        # rather than crowding the Name cell.
         if e.locked:
             p.setPen(self.c_lock)
             p.drawText(QRect(tx, r.top(), 16, r.height()),
                        Qt.AlignVCenter, "\U0001F512")
             tx += 18
-
-        # Reorder-lock glyph — independent flag, distinct icon so it isn't
-        # confused with the "always-on" emoji above (both can show at once).
-        if index.model().is_mod_locked(e.name):
-            lico = icon("lock.png", 14)
-            if not lico.isNull():
-                lico.paint(p, QRect(tx, r.top() + (r.height() - 14) // 2, 14, 14))
-                tx += 18
 
         # Name (elided).
         p.setPen(text_color)
@@ -663,10 +681,22 @@ class ModRowDelegate(QStyledItemDelegate):
     def editorEvent(self, event, model, opt, index):
         if event.type() != QEvent.MouseButtonRelease:
             return False
-        if index.column() not in (COL_NAME, COL_FLAGS, COL_CONFLICTS):
+        if index.column() not in (COL_NAME, COL_FLAGS, COL_CONFLICTS, COL_LOCKED):
             return False
         pos = event.position().toPoint()
         e = model.entry(index.row())
+
+        # Locked column: click anywhere in the cell toggles the mod's reorder
+        # lock directly — no context menu needed. Separators have no reorder
+        # lock (they use the Name-column lock box instead).
+        if index.column() == COL_LOCKED:
+            if e.is_separator:
+                return False
+            view = self.parent()
+            toggle = getattr(view, "_toggle_mod_lock_row", None)
+            if callable(toggle):
+                toggle(index.row())
+            return True
 
         # Flags cell: a click on a flag icon may trigger an action (the update
         # flag opens Change Version). Other flags are inert for now.

--- a/src/gui_qt/modlist_delegate.py
+++ b/src/gui_qt/modlist_delegate.py
@@ -474,12 +474,20 @@ class ModRowDelegate(QStyledItemDelegate):
 
         tx = box.right() + 10
 
-        # Lock glyph.
+        # Lock glyph — MO2 "always-on" flag (emoji).
         if e.locked:
             p.setPen(self.c_lock)
             p.drawText(QRect(tx, r.top(), 16, r.height()),
                        Qt.AlignVCenter, "\U0001F512")
             tx += 18
+
+        # Reorder-lock glyph — independent flag, distinct icon so it isn't
+        # confused with the "always-on" emoji above (both can show at once).
+        if index.model().is_mod_locked(e.name):
+            lico = icon("lock.png", 14)
+            if not lico.isNull():
+                lico.paint(p, QRect(tx, r.top() + (r.height() - 14) // 2, 14, 14))
+                tx += 18
 
         # Name (elided).
         p.setPen(text_color)

--- a/src/gui_qt/modlist_menu.py
+++ b/src/gui_qt/modlist_menu.py
@@ -144,14 +144,15 @@ def build_context_menu(view, index):
 
     if entry.is_separator:
         _build_separator_menu(view, model, row, entry, sel_seps, multi_seps,
-                              act, stub, divider)
+                              act, stub, divider, submenu)
     else:
         _build_mod_menu(view, model, row, entry, sel_mods, multi_mods,
                         act, stub, divider, submenu)
     return menu
 
 
-def _build_separator_menu(view, model, row, entry, sel_seps, multi, act, stub, divider):
+def _build_separator_menu(view, model, row, entry, sel_seps, multi, act, stub,
+                          divider, submenu):
     if multi:
         # ≥2 separators selected.
         all_locked = all(model.is_sep_locked(model.entry(r).display_name)
@@ -160,6 +161,15 @@ def _build_separator_menu(view, model, row, entry, sel_seps, multi, act, stub, d
         act(_mtf("{0} ({1})", _mt("Unlock Separators") if all_locked else _mt("Lock Separators"), n),
             lambda: _set_sep_locks_multi(view, model, sel_seps, not all_locked))
         divider()
+        _others = _other_profiles(view)
+        if _others:
+            _sep_names = _natural_order_names(
+                model, [model.entry(r).name for r in sel_seps])
+            submenu(_mtf("Copy to profile ({0})", n),
+                    _sep_profile_submenu_items(view, _sep_names, sel_seps, _others, False))
+            submenu(_mtf("Move to profile ({0})", n),
+                    _sep_profile_submenu_items(view, _sep_names, sel_seps, _others, True))
+            divider()
         act(_mtf("Remove separators ({0})", n),
             lambda: _remove_separators_multi(view, model, sel_seps))
         return
@@ -171,6 +181,12 @@ def _build_separator_menu(view, model, row, entry, sel_seps, multi, act, stub, d
     act(_mt("Separator settings…"), lambda: _open_sep_settings(view, model, row))
     act(_mt("Add separator above"), lambda: _add_separator(view, model, row, True))
     act(_mt("Add separator below"), lambda: _add_separator(view, model, row, False))
+    _others = _other_profiles(view)
+    if _others:
+        submenu(_mt("Copy to profile"),
+                _sep_profile_submenu_items(view, [entry.name], [row], _others, False))
+        submenu(_mt("Move to profile"),
+                _sep_profile_submenu_items(view, [entry.name], [row], _others, True))
     divider()
     act(_mt("Remove separator"), lambda: _remove_separator(view, model, row))
 
@@ -233,10 +249,12 @@ def _build_mod_menu(view, model, row, entry, sel_mods, multi, act, stub, divider
         _others = _other_profiles(view)
         if _others:
             _copy_names = _natural_order_names(model, _names)
+            _move_names = [nm for nm in _copy_names if not model.is_mod_locked(nm)]
             submenu(_mtf("Copy to profile ({0})", n),
                     _profile_submenu_items(view, _copy_names, sel_mods, _others, False))
             submenu(_mtf("Move to profile ({0})", n),
-                    _profile_submenu_items(view, _copy_names, sel_mods, _others, True))
+                    _profile_submenu_items(view, _move_names, sel_mods, _others, True),
+                    enabled=bool(_move_names))
         act(_mtf("Disable selected ({0})", n),
             lambda: _set_enabled(view, model, sel_mods, False))
         act(_mtf("Enable selected ({0})", n),
@@ -247,6 +265,10 @@ def _build_mod_menu(view, model, row, entry, sel_mods, multi, act, stub, divider
         if len(sel_mods) >= 2:
             act(_mtf("Sort Alphabetically ({0})", n),
                 lambda: _sort_selected_alphabetically(view, model, sel_mods))
+        _all_reorder_locked = all(model.is_mod_locked(nm) for nm in _names)
+        act(_mtf("{0} ({1})",
+                 _mt("Unlock mods") if _all_reorder_locked else _mt("Lock mods"), n),
+            lambda: _set_mod_locks_multi(view, model, sel_mods, not _all_reorder_locked))
         divider()
         # Group: notes
         act(_mtf("Add note ({0})", n), lambda: _open_note_editor(view, _names))
@@ -261,6 +283,7 @@ def _build_mod_menu(view, model, row, entry, sel_mods, multi, act, stub, divider
         return
 
     locked = entry.locked
+    reorder_locked = model.is_mod_locked(entry.name)
     name = entry.name
     _staging_ok = getattr(view, "staging_dir", None) is not None
     # Group 1: manage
@@ -313,12 +336,16 @@ def _build_mod_menu(view, model, row, entry, sel_mods, multi, act, stub, divider
         submenu(_mt("Copy to profile"),
                 _profile_submenu_items(view, [name], [row], _others, False))
         submenu(_mt("Move to profile"),
-                _profile_submenu_items(view, [name], [row], _others, True))
-    if not locked and _separator_choices(model):
+                _profile_submenu_items(view, [name], [row], _others, True),
+                enabled=not reorder_locked)
+    if not locked and not reorder_locked and _separator_choices(model):
         submenu(_mt("Move to separator"),
                 _separator_submenu_items(view, model, [row]))
+    act(_mt("Unlock mod") if reorder_locked else _mt("Lock mod"),
+        lambda: _toggle_mod_lock(view, model, row))
     if not locked:
-        act(_mt("Set priority…"), lambda: _set_priority(view, model, row))
+        act(_mt("Set priority…"), lambda: _set_priority(view, model, row),
+            enabled=not reorder_locked)
     divider()
     # Group 5: info / conflicts / notes
     _has_note = bool(_mod_note(view, name))
@@ -330,7 +357,8 @@ def _build_mod_menu(view, model, row, entry, sel_mods, multi, act, stub, divider
         act(_mt("View Requirements"), lambda: _view_requirements(view, name))
     divider()
     # Group 6: remove
-    act(_mt("Remove mod"), lambda: _remove(view, model, row), enabled=not locked)
+    act(_mt("Remove mod"), lambda: _remove(view, model, row),
+        enabled=not locked and not reorder_locked)
 
 
 def _boundary_names():
@@ -567,7 +595,9 @@ def _move_to_separator(view, model, mod_rows, sep_name):
     from gui_qt.modlist_model import _PINNED_NAMES
     rows = sorted(r for r in mod_rows
                   if not model.entry(r).is_separator
-                  and model.entry(r).name not in _PINNED_NAMES)
+                  and model.entry(r).name not in _PINNED_NAMES
+                  and not model.entry(r).locked
+                  and not model.is_mod_locked(model.entry(r).name))
     if not rows:
         return
     moved_names = {model.entry(r).name for r in rows}
@@ -599,10 +629,11 @@ def _natural_order_names(model, names):
     highest-priority-first) order. Selection-derived name lists follow the
     current DISPLAY row order, which can be a sorted or reverse-priority
     permutation (see ``ModlistModel.natural_entries``) — copy/move-to-profile
-    must register mods in real priority order regardless of how they're
-    currently sorted on screen."""
-    order = {e.name: i for i, e in enumerate(model.natural_entries())
-             if not e.is_separator}
+    must register mods (or separators) in real priority order regardless of
+    how they're currently sorted on screen. Not filtered by is_separator so it
+    orders separator names correctly too — mod and separator names never
+    collide, so a single lookup table serves both callers."""
+    order = {e.name: i for i, e in enumerate(model.natural_entries())}
     return sorted(names, key=lambda nm: order.get(nm, 0))
 
 
@@ -643,6 +674,24 @@ def _copy_to_profile(view, names, enabled_map, target_profile, move):
     cb = getattr(view, "on_copy_to_profile", None)
     if cb is not None and names and target_profile:
         cb(list(names), dict(enabled_map), target_profile, move)
+
+
+def _sep_profile_submenu_items(view, names, sep_rows, others, move: bool):
+    """Build the (profile_name, slot) list for a separator's Copy/Move-to-profile
+    submenu. Marker-only: carries name + color + lock, not the mods grouped
+    under it (those go through the mod Copy/Move-to-profile flow separately)."""
+    return [
+        (prof, (lambda p=prof: _copy_separators_to_profile(
+            view, names, sep_rows, p, move)))
+        for prof in others
+    ]
+
+
+def _copy_separators_to_profile(view, names, sep_rows, target_profile, move):
+    """Delegate the separator copy/move to the window."""
+    cb = getattr(view, "on_copy_separators_to_profile", None)
+    if cb is not None and names and target_profile:
+        cb(list(names), list(sep_rows), target_profile, move)
 
 
 def _read_mod_meta(view, name):
@@ -896,7 +945,8 @@ def _sort_selected_alphabetically(view, model, mod_rows):
     from gui_qt.modlist_model import _PINNED_NAMES
     sel = [model.entry(r) for r in mod_rows]
     sel = [e for e in sel
-           if not e.is_separator and e.name not in _PINNED_NAMES]
+           if not e.is_separator and e.name not in _PINNED_NAMES
+           and not e.locked and not model.is_mod_locked(e.name)]
     if len(sel) < 2:
         return
     # Mods with loose-file conflicts are left in their existing relative order
@@ -1023,6 +1073,10 @@ def _toggle_sep_lock(view, model, row):
     view._toggle_lock_row(row)
 
 
+def _toggle_mod_lock(view, model, row):
+    view._toggle_mod_lock_row(row)
+
+
 def _rename(view, model, row):
     e = model.entry(row)
 
@@ -1145,6 +1199,24 @@ def _open_sep_settings(view, model, row):
 
 # ---- new wired handlers (separator remove / multi, mod multi-remove) -------
 
+def _remove_separator_rows(view, model, sep_rows: "list[int]") -> "list[str]":
+    """Drop every separator row in *sep_rows* (high→low so earlier removals
+    don't shift later indices), one save for the whole batch. No confirmation
+    — callers that need one (the plain Remove menu actions) gate the call
+    behind ConfirmOverlay themselves; the Move-to-profile flow calls this
+    directly, matching the existing mod-Move precedent of not re-confirming
+    the source-side removal."""
+    removed = []
+    for r in sorted(sep_rows, reverse=True):
+        e = model.entry(r)
+        if e is not None and e.is_separator:
+            removed.append(e.name)
+            model.remove_row(r, save=False)
+    if removed:
+        model.save()
+    return removed
+
+
 def _remove_separator(view, model, row):
     e = model.entry(row)
     if e is None or not e.is_separator:
@@ -1153,11 +1225,10 @@ def _remove_separator(view, model, row):
     def _confirmed(ok):
         if not ok:
             return
-        removed = e.name
-        model.remove_row(row)
+        removed = _remove_separator_rows(view, model, [row])
         cb = getattr(view, "on_separators_removed", None)
-        if callable(cb):
-            cb([removed])
+        if callable(cb) and removed:
+            cb(removed)
 
     ConfirmOverlay.show_over(view, "Remove separator",
                              f"Remove separator '{e.display_name}'?",
@@ -1171,15 +1242,7 @@ def _remove_separators_multi(view, model, sep_rows):
     def _confirmed(ok):
         if not ok:
             return
-        # Remove high→low so earlier removals don't shift later row indices.
-        removed = []
-        for r in sorted(sep_rows, reverse=True):
-            e = model.entry(r)
-            if e is not None and e.is_separator:
-                removed.append(e.name)
-                model.remove_row(r, save=False)
-        if removed:
-            model.save()  # single save for the whole batch
+        removed = _remove_separator_rows(view, model, sep_rows)
         cb = getattr(view, "on_separators_removed", None)
         if callable(cb) and removed:
             cb(removed)
@@ -1204,11 +1267,27 @@ def _set_sep_locks_multi(view, model, sep_rows, lock):
         view.viewport().update()
 
 
+def _set_mod_locks_multi(view, model, mod_rows, lock):
+    """Lock/unlock every selected mod's reorder-lock to *lock*, then save once."""
+    changed = False
+    for r in mod_rows:
+        e = model.entry(r)
+        if e is None or e.is_separator:
+            continue
+        if model.is_mod_locked(e.name) != lock:
+            model.toggle_mod_lock(r)
+            changed = True
+    if changed:
+        view._save_mod_lock_state()
+        view.viewport().update()
+
+
 def _remove_mods_multi(view, model, mod_rows):
     """Fully remove every selected mod (one confirm), then drop the rows."""
     rows = [r for r in mod_rows
             if (e := model.entry(r)) is not None
-            and not e.is_separator and not e.locked]
+            and not e.is_separator and not e.locked
+            and not model.is_mod_locked(e.name)]
     if not rows:
         return
     names = [model.entry(r).name for r in rows]
@@ -1270,6 +1349,10 @@ _TR_MARKERS = (
     QT_TRANSLATE_NOOP("ModListMenu", "Endorse selected ({0})"),
     QT_TRANSLATE_NOOP("ModListMenu", "Lock Separator"),
     QT_TRANSLATE_NOOP("ModListMenu", "Lock Separators"),
+    QT_TRANSLATE_NOOP("ModListMenu", "Lock mod"),
+    QT_TRANSLATE_NOOP("ModListMenu", "Unlock mod"),
+    QT_TRANSLATE_NOOP("ModListMenu", "Lock mods"),
+    QT_TRANSLATE_NOOP("ModListMenu", "Unlock mods"),
     QT_TRANSLATE_NOOP("ModListMenu", "Log"),
     QT_TRANSLATE_NOOP("ModListMenu", "Missing Requirements"),
     QT_TRANSLATE_NOOP("ModListMenu", "Missing Requirements ({0})"),

--- a/src/gui_qt/modlist_menu.py
+++ b/src/gui_qt/modlist_menu.py
@@ -232,10 +232,11 @@ def _build_mod_menu(view, model, row, entry, sel_mods, multi, act, stub, divider
         # Group: organise
         _others = _other_profiles(view)
         if _others:
+            _copy_names = _natural_order_names(model, _names)
             submenu(_mtf("Copy to profile ({0})", n),
-                    _profile_submenu_items(view, _names, sel_mods, _others, False))
+                    _profile_submenu_items(view, _copy_names, sel_mods, _others, False))
             submenu(_mtf("Move to profile ({0})", n),
-                    _profile_submenu_items(view, _names, sel_mods, _others, True))
+                    _profile_submenu_items(view, _copy_names, sel_mods, _others, True))
         act(_mtf("Disable selected ({0})", n),
             lambda: _set_enabled(view, model, sel_mods, False))
         act(_mtf("Enable selected ({0})", n),
@@ -593,6 +594,18 @@ def _move_to_separator(view, model, mod_rows, sep_name):
 
 
 # ---- Copy / Move to profile ------------------------------------------------
+def _natural_order_names(model, names):
+    """*names* reordered to match the model's natural (modlist.txt / priority,
+    highest-priority-first) order. Selection-derived name lists follow the
+    current DISPLAY row order, which can be a sorted or reverse-priority
+    permutation (see ``ModlistModel.natural_entries``) — copy/move-to-profile
+    must register mods in real priority order regardless of how they're
+    currently sorted on screen."""
+    order = {e.name: i for i, e in enumerate(model.natural_entries())
+             if not e.is_separator}
+    return sorted(names, key=lambda nm: order.get(nm, 0))
+
+
 def _other_profiles(view):
     """Profile names for this game, excluding the current one ([] if none)."""
     game = getattr(view, "game", None)

--- a/src/gui_qt/modlist_model.py
+++ b/src/gui_qt/modlist_model.py
@@ -159,6 +159,10 @@ class ModListModel(QAbstractTableModel):
         # dragged. Set via set_separator_state(); persistence lives in the view.
         self._collapsed: set[str] = set()
         self._sep_locks: dict[str, bool] = {}
+        # Per-mod reorder lock (keyed by mod name), independent of the MO2
+        # `*`-prefix ModEntry.locked flag. Blocks drag/set_priority/move-to-
+        # separator/sort/remove/move-to-profile; does NOT block rename/notes.
+        self._mod_locks: dict[str, bool] = {}
         # Custom separator background colours, keyed by the internal
         # `..._separator` name (matches the Tk / profile_state storage key).
         self._sep_colors: dict[str, str] = {}
@@ -631,7 +635,8 @@ class ModListModel(QAbstractTableModel):
         f = Qt.ItemIsEnabled | Qt.ItemIsSelectable
         # Draggable unless pinned: boundary separators + locked MODS can't be
         # dragged (a regular separator reads as locked=True but IS draggable).
-        pinned = e.name in _BOUNDARY_NAMES or (not e.is_separator and e.locked)
+        pinned = e.name in _BOUNDARY_NAMES or (
+            not e.is_separator and (e.locked or self.is_mod_locked(e.name)))
         if not pinned:
             f |= Qt.ItemIsDragEnabled
         if not e.is_separator:
@@ -742,6 +747,19 @@ class ModListModel(QAbstractTableModel):
 
     def is_sep_locked(self, sep_name: str) -> bool:
         return bool(self._sep_locks.get(sep_name, False))
+
+    # ---- per-mod reorder lock ---------------------------------------------
+    def set_mod_locks(self, locks: dict[str, bool]) -> None:
+        self._mod_locks = dict(locks or {})
+
+    def is_mod_locked(self, name: str) -> bool:
+        return bool(self._mod_locks.get(name, False))
+
+    def toggle_mod_lock(self, row: int) -> dict[str, bool]:
+        e = self._entries[row]
+        if not e.is_separator:
+            self._mod_locks[e.name] = not self._mod_locks.get(e.name, False)
+        return self._mod_locks
 
     def sep_color(self, sep_name: str) -> str | None:
         """Custom background colour ("#rrggbb") for a separator, keyed by its
@@ -957,6 +975,8 @@ class ModListModel(QAbstractTableModel):
         e = self._entries[row]
         if e.is_separator:
             return
+        if self.is_mod_locked(e.name):
+            return
         nat = self._natural
         nonsep = [i for i, x in enumerate(nat) if not x.is_separator]
         n = len(nonsep)
@@ -1059,7 +1079,8 @@ class ModListModel(QAbstractTableModel):
         call save() once at the end — save() fires on_saved() which kicks off a
         full conflict/filemap rebuild, so per-row saving rebuilds N times."""
         e = self._entries[row]
-        if e.name in _PINNED_NAMES or (not e.is_separator and e.locked):
+        if e.name in _PINNED_NAMES or (
+                not e.is_separator and (e.locked or self.is_mod_locked(e.name))):
             return
         self.beginRemoveRows(QModelIndex(), row, row)
         del self._entries[row]
@@ -1181,7 +1202,7 @@ class ModListModel(QAbstractTableModel):
             e = self._entries[r]
             if e.name in _PINNED_NAMES:
                 return False
-            if not e.is_separator and e.locked:
+            if not e.is_separator and (e.locked or self.is_mod_locked(e.name)):
                 return False
         # Keep within the movable span (below Overwrite, above Root Folder).
         lo, hi = self._movable_span()
@@ -1225,7 +1246,7 @@ class ModListModel(QAbstractTableModel):
             e = self._entries[r]
             if e.name in _PINNED_NAMES:
                 return False
-            if not e.is_separator and e.locked:
+            if not e.is_separator and (e.locked or self.is_mod_locked(e.name)):
                 return False
         lo, hi = self._movable_span()
         if first < lo or last >= hi:

--- a/src/gui_qt/modlist_model.py
+++ b/src/gui_qt/modlist_model.py
@@ -1,7 +1,7 @@
 """Modlist model — QAbstractTableModel over the ModEntry list.
 
 Columns: Mod Name, Category, Flags, Conflicts, Installed, Version, Author,
-Priority, Size (the checkbox is painted into column 0 by the delegate). Fed by
+Priority, Size, Locked (the checkbox is painted into column 0 by the delegate). Fed by
 read_modlist; version / installed / flags / conflicts / authors are optional
 dicts keyed by mod name (blank when absent). Index 0 = highest priority; the Priority column shows a descending
 number (highest-priority row = largest value).
@@ -40,8 +40,9 @@ COL_VERSION = 5
 COL_AUTHOR = 6
 COL_PRIORITY = 7
 COL_SIZE = 8
+COL_LOCKED = 9
 COLUMNS = ["Mod Name", "Category", "Flags", "Conflicts", "Installed",
-           "Version", "Author", "Priority", "Size"]
+           "Version", "Author", "Priority", "Size", "Locked"]
 
 # COLUMNS doubles as canonical persistence keys, so it must stay untranslated;
 # headerData() translates each label at display time via self.tr(COLUMNS[i]).
@@ -58,6 +59,7 @@ _COLUMN_TR_MARKERS = [
     QT_TRANSLATE_NOOP("ModListModel", "Author"),
     QT_TRANSLATE_NOOP("ModListModel", "Priority"),
     QT_TRANSLATE_NOOP("ModListModel", "Size"),
+    QT_TRANSLATE_NOOP("ModListModel", "Locked"),
 ]
 
 # Custom roles for the delegate.

--- a/src/gui_qt/modlist_view.py
+++ b/src/gui_qt/modlist_view.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (
 from gui_qt.modlist_model import (
     ModListModel, COLUMNS, COL_NAME, COL_CATEGORY, COL_PRIORITY, COL_FLAGS,
     COL_CONFLICTS, COL_INSTALLED, COL_VERSION, COL_AUTHOR, COL_SIZE,
-    HighlightRole,
+    COL_LOCKED, HighlightRole,
 )
 from gui_qt.modlist_delegate import ModRowDelegate, SEP_H
 from gui_qt import column_state
@@ -45,21 +45,27 @@ class _StayOpenMenu(QMenu):
 COL_DEFAULTS = {
     COL_CATEGORY: 120, COL_FLAGS: 70, COL_CONFLICTS: 95, COL_INSTALLED: 100,
     COL_VERSION: 90, COL_AUTHOR: 110, COL_PRIORITY: 75, COL_SIZE: 85,
+    COL_LOCKED: 60,
 }
 COL_MINS = {
     COL_NAME: 120, COL_CATEGORY: 90, COL_FLAGS: 60, COL_CONFLICTS: 90,
     COL_INSTALLED: 90, COL_VERSION: 80, COL_AUTHOR: 80, COL_PRIORITY: 70,
-    COL_SIZE: 70,
+    COL_SIZE: 70, COL_LOCKED: 50,
 }
 NAME_MIN = COL_MINS[COL_NAME]
 
 # Columns shown by default on a fresh INI (no persisted state). Tk parity:
 # Category, Installed, Size are hidden until the user enables them; Author
-# (Nexus uploader) is likewise opt-in.
-_FIRST_RUN_HIDDEN = {COL_CATEGORY, COL_INSTALLED, COL_AUTHOR, COL_SIZE}
+# (Nexus uploader) is likewise opt-in. Locked is a new (Qt-only) column and
+# stays opt-in too — most mods are never locked, so showing it for everyone
+# by default would just be a mostly-empty column.
+_FIRST_RUN_HIDDEN = {COL_CATEGORY, COL_INSTALLED, COL_AUTHOR, COL_SIZE, COL_LOCKED}
 
 # Header column → sort key (Tk _DATA_COL_SORT_KEYS; keys persisted by name via
-# column_state's sort_col, which stores the COLUMNS display name).
+# column_state's sort_col, which stores the COLUMNS display name). COL_LOCKED
+# is intentionally absent — clicking its header is a no-op (see
+# _on_header_sort_clicked/sort_triangle_spec's `key is None` guards); it's a
+# click-to-toggle control column, not a sortable data field.
 _COL_TO_SORTKEY = {
     COL_NAME: "name", COL_CATEGORY: "category", COL_FLAGS: "flags",
     COL_CONFLICTS: "conflicts", COL_INSTALLED: "installed",
@@ -272,7 +278,7 @@ class ModListView(QTreeView):
         btn.setCursor(Qt.ArrowCursor)
         btn.setFocusPolicy(Qt.NoFocus)
         btn.setAutoRaise(True)
-        btn.setToolTip(self.tr("Show / hide columns"))
+        btn.setToolTip(self.tr("Show / Hide columns"))
         # Opaque header-coloured background so it sits cleanly over the Mod Name
         # header text; hover/press come from the global QToolButton QSS.
         bg = _c(active_palette(), "BG_HEADER")
@@ -363,6 +369,12 @@ class ModListView(QTreeView):
 
     def _set_column_visible(self, col: int, visible: bool):
         self.setColumnHidden(col, not visible)
+        if col == COL_LOCKED:
+            # A deliberate toggle (either way) from the show/hide menu is now
+            # the user's real preference — it should persist normally and
+            # never get silently reverted by load_mod_lock_state()'s auto-show
+            # nudge on a later profile switch.
+            self._locked_col_auto_shown = False
         if visible:
             # Qt collapses a hidden section's width to 0; restore a sensible
             # width so the re-shown column is actually visible (not a 0-px
@@ -414,7 +426,26 @@ class ModListView(QTreeView):
 
     def load_mod_lock_state(self):
         """Read per-mod reorder-lock state for the active profile into the
-        model. Called by the window after a modlist reload."""
+        model. Called by the window after a modlist reload (profile switch,
+        mod install/remove, refresh, ...).
+
+        The Locked column is opt-in (hidden by default — see _FIRST_RUN_HIDDEN)
+        so it doesn't clutter the view for the vast majority of profiles that
+        never use it. But an IMPORTED/shared profile may carry real locks the
+        recipient doesn't know about and has no reason to have pre-enabled the
+        column for — so the FIRST time this profile is seen with any mod
+        actually locked, force the column visible regardless of the persisted/
+        default column state, so the lock (and why those mods won't reorder)
+        is discoverable.
+
+        This only fires once per profile ACTIVATION, not on every reload —
+        reloads (installs, refreshes, ...) are far more frequent than profile
+        switches, and re-forcing the column open on each one would make it
+        impossible to hide again while viewing a locked profile. If the user
+        switches away and back to the same locked profile, it's nudged open
+        again; if they switch to a different profile with no locks, an
+        auto-shown column reverts to hidden (a genuinely user-shown column,
+        i.e. it was already visible before we nudged it, never gets touched)."""
         locks = {}
         if self.profile_dir is not None:
             try:
@@ -423,6 +454,22 @@ class ModListView(QTreeView):
             except Exception:
                 pass
         self.model().set_mod_locks(locks)
+
+        changed_profile = getattr(self, "_locked_col_last_profile", object()) != self.profile_dir
+        self._locked_col_last_profile = self.profile_dir
+        if not changed_profile:
+            return
+        if any(locks.values()):
+            if self.isColumnHidden(COL_LOCKED):
+                self.setColumnHidden(COL_LOCKED, False)
+                if self.columnWidth(COL_LOCKED) <= 0:
+                    self.header().resizeSection(COL_LOCKED, COL_DEFAULTS.get(COL_LOCKED, 60))
+                self._fit_name_to_width()
+                self._locked_col_auto_shown = True
+        elif getattr(self, "_locked_col_auto_shown", False):
+            self.setColumnHidden(COL_LOCKED, True)
+            self._fit_name_to_width()
+            self._locked_col_auto_shown = False
 
     def _apply_separator_spanning(self):
         """Separator rows span all columns so the band + centred name + the

--- a/src/gui_qt/modlist_view.py
+++ b/src/gui_qt/modlist_view.py
@@ -412,6 +412,18 @@ class ModListView(QTreeView):
         self._apply_separator_spanning()
         self.apply_collapse()
 
+    def load_mod_lock_state(self):
+        """Read per-mod reorder-lock state for the active profile into the
+        model. Called by the window after a modlist reload."""
+        locks = {}
+        if self.profile_dir is not None:
+            try:
+                from Utils.profile_state import read_mod_locks
+                locks = read_mod_locks(self.profile_dir)
+            except Exception:
+                pass
+        self.model().set_mod_locks(locks)
+
     def _apply_separator_spanning(self):
         """Separator rows span all columns so the band + centred name + the
         right-side lock box use the full row width."""
@@ -532,6 +544,11 @@ class ModListView(QTreeView):
         self._save_separator_state()
         self.viewport().update()
 
+    def _toggle_mod_lock_row(self, row):
+        self.model().toggle_mod_lock(row)
+        self._save_mod_lock_state()
+        self.viewport().update()
+
     def _lock_box_click(self, row: int, shift: bool):
         """Handle a click on a separator's lock box. Plain click toggles the one
         separator and records it as the range anchor; shift-click applies the
@@ -571,6 +588,15 @@ class ModListView(QTreeView):
             write_separator_locks(self.profile_dir, m._sep_locks)
         except Exception as exc:
             print(f"[gui_qt] separator state save failed: {exc}", flush=True)
+
+    def _save_mod_lock_state(self):
+        if self.profile_dir is None:
+            return
+        try:
+            from Utils.profile_state import write_mod_locks
+            write_mod_locks(self.profile_dir, self.model()._mod_locks)
+        except Exception as exc:
+            print(f"[gui_qt] mod lock state save failed: {exc}", flush=True)
 
     # ---- sticky separator header -------------------------------------------
     def _sticky_sep_info(self) -> tuple[int, QRect] | None:
@@ -829,7 +855,7 @@ class ModListView(QTreeView):
         from gui_qt.modlist_model import _PINNED_NAMES
         if e.name in _PINNED_NAMES:
             return None
-        if not e.is_separator and e.locked:
+        if not e.is_separator and (e.locked or m.is_mod_locked(e.name)):
             return None
         # Only a LOCKED separator carries its whole block (Tk parity: collapse
         # affects visibility, never the drag payload). An unlocked separator —
@@ -843,7 +869,9 @@ class ModListView(QTreeView):
         if row in sel and len(sel) > 1:
             carry = [r for r in sel
                      if m.entry(r).name not in _PINNED_NAMES
-                     and not (not m.entry(r).is_separator and m.entry(r).locked)]
+                     and not (not m.entry(r).is_separator
+                              and (m.entry(r).locked
+                                   or m.is_mod_locked(m.entry(r).name)))]
             return carry or [row]
         return [row]
 

--- a/src/gui_qt/plugin_view.py
+++ b/src/gui_qt/plugin_view.py
@@ -468,7 +468,7 @@ class PluginView(QTreeView):
         btn.setCursor(Qt.ArrowCursor)
         btn.setFocusPolicy(Qt.NoFocus)
         btn.setAutoRaise(True)
-        btn.setToolTip(self.tr("Show / hide columns"))
+        btn.setToolTip(self.tr("Show / Hide columns"))
         bg = _c(active_palette(), "BG_HEADER")
         btn.setStyleSheet(
             f"QToolButton {{ background: {bg}; border: none; padding: 0px; }}")

--- a/src/translations/amethyst_en.ts
+++ b/src/translations/amethyst_en.ts
@@ -6510,8 +6510,8 @@ How would you like to handle the existing mod?</translation>
 <context>
     <name>ModListView</name>
     <message>
-        <source>Show / hide columns</source>
-        <translation>Show / hide columns</translation>
+        <source>Show / Hide columns</source>
+        <translation>Show / Hide columns</translation>
     </message>
     <message>
         <source>Enabled</source>
@@ -7893,8 +7893,8 @@ Drag a plugin from the left pane to add a rule.</translation>
 <context>
     <name>PluginView</name>
     <message>
-        <source>Show / hide columns</source>
-        <translation>Show / hide columns</translation>
+        <source>Show / Hide columns</source>
+        <translation>Show / Hide columns</translation>
     </message>
     <message>
         <source>Filters</source>

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "v2.0.6-beta.4"
+__version__ = "v2.0.6-beta.5"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "v2.0.6-beta.5"
+__version__ = "v2.0.6-beta.6"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.4"
+__version__ = "v2.0.6-beta.4"


### PR DESCRIPTION
# PR title

Per-mod reorder lock, separator copy/move to profile, and priority-order/share-code fixes

# Branch / commit range

`main` (this fork), commits `4d7de8d4..c6e7fe24` (5 commits, today):

- `4d7de8d4` Fix mods not retaining priority order when copied/moved to another profile
- `3a2e4d3a` Add per-mod reorder lock and Copy/Move separators to profile
- `0dc51960` Add project CLAUDE.md and release/CI-CD rule
- `ba8b87be` Move mod reorder-lock to its own column, auto-surface it, fix share-code lock export/import
- `c6e7fe24` Bump version to v2.0.6-beta.6

Per this fork's CLAUDE.md convention, this PR is cut from a clean branch off `upstream/main` (the 5 commits above, cherry-picked) rather than pointed at this fork's messier `main` history.

---

## Summary

- **Fixed a real ordering bug**: copying/moving mods to another profile used the modlist's current *display* row order (which can be a column sort or reverse-priority view) instead of true priority order, so copied mods could land in the wrong relative order in the target profile.
- **Added a per-mod reorder lock**, independent of the existing MO2 `*` "always-on" flag. A locked mod can't be dragged, sorted, moved to a separator, removed, or moved to another profile — but can still be renamed and noted. Exposed via a right-click Lock/Unlock action (single + multi-select) and a dedicated **Locked** column (click to toggle, same visual language as the separator lock boxes). The column is hidden by default but auto-surfaces the first time a loaded profile actually has a locked mod, so a shared/imported modlist's locks are discoverable without the recipient needing to know the column exists.
- **Added Copy/Move-to-profile for separators** (name, colour, lock state — not their mods), preserving relative order, reusing the same ordering fix as above.
- **Fixed the share-code (`AMMCODE1:`) export/import pipeline silently dropping all lock state**:
  - Mod reorder-locks were never included in the manifest at all.
  - Separator locks were computed/written under the wrong dict key on *both* export and import (internal `..._separator` name vs. the display name the UI actually reads), so a locked separator always came back unlocked even when the data made it through.
- Minor: fixed "Show / hide columns" → "Show / Hide columns" tooltip capitalization; added a project `CLAUDE.md` + a path-triggered `.claude/rules/release-cicd.md` for future Claude Code sessions working in this repo.

## Details

### 1. Priority-order bug on Copy/Move to profile (`4d7de8d4`)
`gui_qt/modlist_menu.py`'s `_copy_to_profile` flow built its mod list from `sel_mods` in on-screen row order. If the modlist was sorted by a column, or in reverse-priority display mode, that row order didn't match `modlist.txt`'s real priority order — so the copied block landed in the target profile in the wrong order. Fixed by reordering the selection through a new `_natural_order_names()` helper (sorts by position in `model.natural_entries()`) before handing it to the existing copy/move plumbing.

### 2. Per-mod reorder lock + separator copy/move (`3a2e4d3a`)
- New `mod_locks: dict[str, bool]` key in each profile's `profile_state.json`, migrated on rename (`Utils/mod_rename.py`).
- `ModListModel.is_mod_locked()` / `toggle_mod_lock()`, wired into every reorder path (`flags()`, `set_priority()`, `move_block()`, `move_block_display()`, `remove_row()`) plus the two menu-level functions (`_move_to_separator`, `_sort_selected_alphabetically`) that had a pre-existing gap letting even the old `*`-locked mods slip through.
- Context menu: single "Lock mod"/"Unlock mod" action; batch "Lock mods (n)"/"Unlock mods (n)" for multi-select; "Set priority…" now greys out instead of hiding when locked.
- New `Utils/separator_copy.py`: marker-only separator copy (name + colour + lock, not the grouped mods), with the same collision-skip/ordering behaviour as mod copy. Wired into new "Copy to profile"/"Move to profile" submenus on the separator context menu.
- Fixed `_on_separators_removed` leaking stale `separator_locks`/`collapsed_seps` entries on separator removal.

### 3. Dedicated Locked column + auto-surface + share-code fixes (`ba8b87be`)
- Moved the reorder-lock indicator out of the Name column into its own **Locked** column (`COL_LOCKED`), consistent with Category/Flags/Priority/etc. — click anywhere in the cell to toggle.
- Hidden by default (`_FIRST_RUN_HIDDEN`), but `ModListView.load_mod_lock_state()` now force-shows it the first time a profile activation has any mod actually locked, and reverts it if a later profile has none — without touching the persisted column preference if the user explicitly showed/hid it themselves.
- `Utils/profile_export.py`: `load_rows()`/`build_manifest()` now carry a `"locked"` flag per mod (sourced from `mod_locks`); `_separator_blocks()`'s lock lookup now uses the separator's *display* name (was using the internal `..._separator` name, which never matched `separator_locks`' keys).
- `Utils/collection_install.py`: new `_apply_schema_locked_mods()` (mirrors the existing `_apply_schema_disabled_mods` resolution logic) writes imported mod locks into the target profile; `_apply_manifest_separators()`'s lock write now uses the display name too.
- `Show / hide columns` → `Show / Hide columns` tooltip fix (modlist + plugin panel).

### 4. Repo docs (`0dc51960`)
Added `CLAUDE.md` (fork conventions: version-always-wins, `sync-upstream.sh` gate, clean-branch-for-upstream-PR rule) and `.claude/rules/release-cicd.md` (path-triggered on workflow YAML / `Changelog.txt` edits).

### 5. Version bump (`c6e7fe24`)
`v2.0.6-beta.5` → `v2.0.6-beta.6`, with the corresponding `Changelog.txt` entries.

---

## Test plan

- [x] Verified the priority-order fix and the reorder-lock guards (drag, `set_priority`, `move_block`/`move_block_display`, `_move_to_separator`, `_sort_selected_alphabetically`) with direct model-level scripts (locked mod blocked, unlocked mod unaffected).
- [x] Verified `Utils/separator_copy.py` end-to-end against temp profile dirs: order preserved, collisions skipped, colour keyed by internal name, lock keyed by display name.
- [x] Verified the Locked-column paint + click-to-toggle path (delegate `paint()`/`editorEvent()`) with a scripted Qt smoke test.
- [x] Verified the auto-show/auto-hide-once-per-activation logic against an isolated (non-real) `amethyst.ini`: fresh hidden → shows on a locked profile → hides on an unlocked one → re-shows on returning to the locked one → a user's explicit show/hide is never overridden.
- [x] Verified the share-code fixes with isolated round-trip tests: `load_rows`/`build_manifest` now emit `"locked"` for mods; `_separator_blocks` now emits `"locked"` for separators; `_apply_schema_locked_mods` and `_apply_manifest_separators` write both back under the keys the UI actually reads (`read_mod_locks`/`read_separator_locks`).
- [x] `gui_qt.app` (the whole application) imports cleanly after every change in this range; the real app was launched from source multiple times during the session with no crash (only a harmless venv-path `RuntimeWarning`).
- [x] CI: `Test Build` workflow run [29854661545](https://github.com/TheMrGeeBee/Amethyst-Mod-Manager/actions/runs/29854661545) — AppImage, Flatpak, libloot ×2 all green.
- [ ] Not done: interactive click-through in the live GUI (right-click menus, drag-and-drop, the new column) — verification above is script/model-level plus a startup smoke test, not a human UI pass.
- [ ] Not done: the *other* export method (per-mod version/optional picker, the ".amethyst" bundle export) still doesn't preserve load order — explicitly out of scope for this batch per your earlier note ("that's a fix for later").
