### PR TITLE
Fix Stellar Blade: dwmapi.dll and LogicMods pak routing

### DIFF
--- a/Custom Handlers/Stellar_Blade.json
+++ b/Custom Handlers/Stellar_Blade.json
@@ -70,7 +70,7 @@
       "flatten": true
     },
     {
-      "dest": "Binaries/Win64/ue4ss",
+      "dest": "Binaries/Win64",
       "filenames": [
         "dwmapi.dll"
       ],
@@ -80,6 +80,13 @@
       "dest": "Binaries/Win64/ue4ss/Mods",
       "filenames": [
         "mods.txt"
+      ],
+      "flatten": true
+    },
+    {
+      "dest": "Content/Paks",
+      "folders": [
+        "LogicMods"
       ],
       "flatten": true
     },


### PR DESCRIPTION
## Problem
Two routing bugs in the Stellar Blade preset break UE4SS-dependent mods:

1. **dwmapi.dll misrouted** — the rule sends it to `Binaries/Win64/ue4ss`
   with `flatten: true`, but dwmapi.dll works via DLL search-order
   hijacking and must sit directly beside `SB-Win64-Shipping.exe` in
   `Binaries/Win64`.

2. **LogicMods paks misrouted** — the only `.pak`-extension rule is a
   blind catch-all to `Content/Paks/~mods` with no LogicMods exception.
   The engine's UE5 base class has a built-in safeguard for this
   (`_ue5_shared_pre_rules`: `LogicMods` folder → `Content/Paks`), but
   per-game custom rules are checked before shared built-in rules, so
   Stellar Blade's catch-all steals the match first and the safeguard
   never fires. Result: LogicMods-folder pak mods (e.g. the "Custom
   Nanosuit System" / DekCNS mod) end up at
   `Content/Paks/~mods/LogicMods/...` instead of `Content/Paks/LogicMods/...`,
   the only path UE4SS's `BPModLoaderMod` scans — so blueprint-injection
   mods silently fail to load with no error.

## Fix
- Changed the dwmapi.dll rule's `dest` to `Binaries/Win64`.
- Inserted a `LogicMods`-folder rule (mirroring the engine's own
  built-in one) immediately before the `.pak` catch-all rule.

## Testing
Both fixes verified in-game on Linux/Proton: UE4SS loads and logs a
clean session with hooks registered, and the CNS mod's N/Alt+N keybind
now works correctly (previously silent no-op — BPModLoaderMod found
no LogicMods mods to scan).