### PR TITLE
Fix bsa_extract.py exception handling; add pylint config

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,74 @@
+[MAIN]
+
+# lz4 and gi (GObject Introspection — used by the XDG portal file chooser in
+# Utils/portal_filechooser.py) are compiled/dynamically-generated bindings
+# that pylint's static analyzer (astroid) cannot introspect from source
+# alone. Allow-listing them makes pylint actually import and inspect the
+# *real* module at analysis time instead of guessing from source — this
+# eliminates false positives like "DBusProxyFlags" having "no member", while
+# still correctly catching genuine mistakes (it still flags
+# Utils/bsa_extract.py's reference to the nonexistent
+# lz4.frame.LZ4FrameError, which is a real bug, not a tooling gap).
+#
+# PySide6 is deliberately NOT here: dynamically introspecting it trades the
+# import-resolution false positives for a worse one — pylint can't model
+# per-instance bound Signal objects, so every `widget.clicked.connect(...)`
+# gets flagged as "Method '<no-name>' has no 'connect' member". Trusting it
+# via ignored-modules below (no introspection at all) avoids both problems.
+extension-pkg-allow-list=lz4,gi
+
+# Utils/deploy.py is a façade that re-exports ~3000 lines' worth of names
+# from six sibling modules via `from X import *` (see that file's own
+# docstring). astroid can't trace multi-hop wildcard re-exports, so it
+# reports every name imported from it as missing even though all of them
+# resolve fine at runtime (verified directly — see PR discussion).
+#
+# PySide6 is here (not extension-pkg-allow-list — see above) purely so
+# `from PySide6.QtCore import Qt, Signal` etc. stop being reported as
+# missing; pylint just trusts the import without inspecting members.
+ignored-modules=Utils.deploy,PySide6
+
+
+[MESSAGES CONTROL]
+
+disable=
+    # --- Deliberate, pervasive project conventions — not defects ---
+    import-outside-toplevel,
+    broad-exception-caught,
+    missing-module-docstring,
+    missing-function-docstring,
+    missing-class-docstring,
+    protected-access,
+    invalid-name,
+    line-too-long,
+    duplicate-code,
+    unnecessary-lambda-assignment,
+    unnecessary-lambda,
+    disallowed-name,
+    global-statement,
+    multiple-statements,
+    attribute-defined-outside-init,
+    redefined-builtin,   # gui_qt/app.py deliberately shadows print with a crash-proof wrapper
+                         # (Utils.app_log.safe_print) — documented at its import site.
+
+    # --- Design/complexity thresholds tuned for small modules — this is a
+    # single large-window desktop app (gui_qt/app.py is one MainWindow class
+    # by design; wizard/view classes follow the same builder-method pattern) ---
+    too-many-locals,
+    too-many-branches,
+    too-many-statements,
+    too-many-arguments,
+    too-many-positional-arguments,
+    too-many-instance-attributes,
+    too-many-nested-blocks,
+    too-many-return-statements,
+    too-many-public-methods,
+    too-many-lines,
+    too-few-public-methods,
+
+# Deliberately NOT disabled, despite showing up in the noise:
+#   unused-argument — mostly game-handler interface methods (deploy/restore
+#   signatures shared across every Games/*.py handler) that don't need every
+#   parameter; genuinely unused params are already exempted when prefixed
+#   with "_" (pylint's default dummy-variables-rgx). Left enabled since it
+#   still catches real accidental-unused-parameter mistakes elsewhere.

--- a/src/Utils/bsa_extract.py
+++ b/src/Utils/bsa_extract.py
@@ -99,7 +99,7 @@ def extract_bsa(
     except BsaExtractError:
         raise
     except (OSError, struct.error, ValueError, zlib.error,
-            lz4.frame.LZ4FrameError) as exc:
+            RuntimeError) as exc:
         raise BsaExtractError(f"failed to extract {bsa_path.name}: {exc}") from exc
 
 
@@ -127,7 +127,7 @@ def _extract(
         archive_flags,
         folder_count,
         file_count,
-        total_folder_name_length,
+        _total_folder_name_length,
         total_file_name_length,
         _file_flags,
     ) = struct.unpack("<IIIIIIII", header)


### PR DESCRIPTION
## Summary

This is a small bugfix + tooling PR, unrelated to the Profile Groups feature PR (#310).

- **Bug fix in `Utils/bsa_extract.py`**: `extract_bsa()`'s except tuple referenced `lz4.frame.LZ4FrameError`, which does not exist in the `lz4` package — verified against the installed package version, the [official docs](https://python-lz4.readthedocs.io/en/stable/lz4.frame.html), and `lz4.frame`'s own source (it only ever raises `RuntimeError`/`ValueError`/`TypeError`). Since except-tuples are evaluated lazily, this bug is latent: it only bites if extraction ever hits a genuine `OSError`/`struct.error`/`ValueError`/`zlib.error`, at which point — instead of cleanly wrapping it as `BsaExtractError` like the rest of the codebase expects — it would itself throw a fresh `AttributeError` and mask the real error. Replaced with `RuntimeError`, the exception type `lz4.frame` actually raises on failure.
- **Minor cleanup, same file**: `total_folder_name_length` was unpacked from the BSA header but never used (unlike its neighbor `total_file_name_length`, used later to read the file-name block). Prefixed with `_` to match the file's existing convention for intentionally-unused `struct.unpack` fields (see `_file_flags` on the same line group).
- **Added `.pylintrc`**: this came from investigating why VS Code's Pylint extension shows 1000+ problems in `app.py` alone with no project config present (so it runs on bare defaults). Ran pylint across the full `src/` tree and manually verified a representative sample of every message category before deciding to disable anything. Result: 9,317 → 621 messages (~93%), with every disable commented inline explaining why. The two headline causes:
  - `no-name-in-module`/`no-member` (the bulk of it): pylint/astroid can't introspect PySide6's compiled bindings or trace `Utils/deploy.py`'s multi-module wildcard-import facade — confirmed by directly importing the "missing" names at runtime.
  - The rest: pylint's generic defaults (docstrings, complexity thresholds, `broad-exception-caught`, `import-outside-toplevel`, naming) colliding with this codebase's own consistent, deliberate conventions (lazy imports, graceful-degradation excepts, game-titled module/class names, Qt builder-pattern init, a large single-window `MainWindow` class).
  - The lz4 bug above is the one genuine defect that survived the full triage of every remaining "error"/interesting-"warning" category — everything else (Optional-narrowing across guards/comprehensions, base-class-stub-overridden-by-subclass polymorphism, a couple of GObject-Introspection static-factory-method quirks introduced by allow-listing `gi`) was individually traced back to a specific, verified tooling blind spot, not a real bug. Details in the commit message and PR review history if useful.

## Test plan
- [x] `bsa_extract.py` still imports and parses cleanly; the only remaining pylint finding in that file (`try-except-raise` on the pre-existing `except BsaExtractError: raise`) is intentionally left as-is — see inline note in the review, it's defensive against a future broadening of the except clause below it, not dead code today.
- [x] Verified with `.pylintrc` applied: `lz4.frame` reference resolves correctly and no longer triggers `no-member`.
- [ ] Have not exercised an actual BSA v105 extraction failure path end-to-end (would need a corrupted archive to trigger); the fix restores intended behavior (wrap as `BsaExtractError`) rather than changing it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>