### PR TITLE
Preserve root package metadata during reinstall

### DIFF
--- a/src/Nexus/nexus_meta.py
+++ b/src/Nexus/nexus_meta.py
@@ -391,6 +391,45 @@ def build_meta_from_download(
     return meta
 
 
+def merge_reinstall_metadata(
+    refreshed: "NexusModMeta | None",
+    installed: "NexusModMeta | None",
+) -> NexusModMeta:
+    """Build metadata for reinstalling the same installed archive.
+
+    API/download metadata remains authoritative when available.  A local
+    reinstall can reuse stable package identity from the installed metadata,
+    while install-layout and collection ownership must survive either path.
+    Transient update-check and user-state fields are deliberately excluded.
+    """
+    meta = copy.copy(refreshed) if refreshed is not None else NexusModMeta()
+    if installed is None:
+        return meta
+
+    stable_identity = (
+        "game_domain",
+        "mod_id",
+        "file_id",
+        "version",
+        "author",
+        "uploaded_by",
+        "nexus_name",
+        "nexus_file_name",
+        "nexus_url",
+        "description",
+        "category_id",
+        "category_name",
+        "file_category",
+    )
+    for field_name in stable_identity:
+        if not getattr(meta, field_name):
+            setattr(meta, field_name, getattr(installed, field_name))
+
+    meta.root_folder = installed.root_folder
+    meta.from_collection = installed.from_collection
+    return meta
+
+
 # ---------------------------------------------------------------------------
 # Scanning
 # ---------------------------------------------------------------------------

--- a/src/gui_qt/app.py
+++ b/src/gui_qt/app.py
@@ -5306,18 +5306,23 @@ class MainWindow(QMainWindow):
 
         from gui_qt.modlist_menu import _installation_archive, _read_mod_meta
         preferred: dict[str, str] = {}   # archive path → forced folder name
+        metas: dict[str, object] = {}    # archive path → reinstall metadata
         paths: list[str] = []
-        redownload: list[tuple] = []     # (mod_name, domain, mod_id, file_id, filename)
+        redownload: list[tuple] = []     # (..., filename, installed_meta)
         missing: list[str] = []          # no archive AND no Nexus info to redownload
+        from Nexus.nexus_meta import merge_reinstall_metadata
         for nm in names:
+            meta = _read_mod_meta(self._modlist_view, nm)
             arc = _installation_archive(self._modlist_view, nm)
             if arc is not None:
-                paths.append(str(arc))
-                preferred[str(arc)] = nm
+                archive_path = str(arc)
+                paths.append(archive_path)
+                preferred[archive_path] = nm
+                if meta is not None:
+                    metas[archive_path] = merge_reinstall_metadata(None, meta)
                 continue
             # Archive gone - fall back to a Nexus redownload if this mod carries
             # a modid + fileid (and a resolvable game domain) in its meta.ini.
-            meta = _read_mod_meta(self._modlist_view, nm)
             mod_id = int(getattr(meta, "mod_id", 0) or 0) if meta is not None else 0
             file_id = int(getattr(meta, "file_id", 0) or 0) if meta is not None else 0
             from Nexus.nexus_meta import normalise_game_domain
@@ -5327,7 +5332,8 @@ class MainWindow(QMainWindow):
                 domain = getattr(game, "nexus_game_domain", "") or ""
             if mod_id > 0 and file_id > 0 and domain:
                 redownload.append((nm, domain, mod_id, file_id,
-                                   getattr(meta, "installation_file", "") or ""))
+                                   getattr(meta, "installation_file", "") or "",
+                                   meta))
             else:
                 missing.append(nm)
                 self._append_log(f"[reinstall] {nm} - install archive not found and "
@@ -5357,7 +5363,8 @@ class MainWindow(QMainWindow):
         if paths:
             # clear_archives=False: reinstall CONSUMES an existing archive the
             # user kept - deleting it would make the next reinstall impossible.
-            self._install_paths(paths, preferred_names=preferred,
+            self._install_paths(paths, metas=metas or None,
+                                preferred_names=preferred,
                                 clear_archives=False)
         if redownload:
             self._redownload_and_reinstall(redownload)
@@ -5369,7 +5376,7 @@ class MainWindow(QMainWindow):
         Replace-All). Premium users get a direct download; non-premium users get
         each mod's Nexus files page opened in the browser (site 'Download with
         Mod Manager' flow). `items` = [(mod_name, domain, mod_id, file_id,
-        filename), …]."""
+        filename, installed_meta), …]."""
         api = self._ensure_nexus_api()
         if api is None:
             self._notify(
@@ -5441,7 +5448,8 @@ class MainWindow(QMainWindow):
         def _download_all():
             import concurrent.futures as _cf
             from Nexus.nexus_download import NexusDownloader
-            from Nexus.nexus_meta import build_meta_from_download
+            from Nexus.nexus_meta import (build_meta_from_download,
+                                          merge_reinstall_metadata)
             from Utils.config_paths import get_download_cache_dir_for_game
             dest = get_download_cache_dir_for_game(getattr(game, "name", "") or "")
             downloader = NexusDownloader(api, download_dir=dest)
@@ -5450,7 +5458,7 @@ class MainWindow(QMainWindow):
             lock = threading.Lock()
 
             def _one(item):
-                mod_name, domain, mod_id, file_id, filename = item
+                mod_name, domain, mod_id, file_id, filename, installed_meta = item
                 try:
                     def _on_progress(cur, tot, _m=mod_name):
                         with progress_lock:
@@ -5483,6 +5491,7 @@ class MainWindow(QMainWindow):
                         prebuilt = build_meta_from_download(
                             game_domain=domain, mod_id=mod_id, file_id=file_id,
                             archive_name=result.file_name, mod_info=mod_info)
+                        prebuilt = merge_reinstall_metadata(prebuilt, installed_meta)
                     except Exception as exc:
                         self._op_log.emit(
                             f"[reinstall] Warning - could not build metadata: {exc}")
@@ -5509,7 +5518,7 @@ class MainWindow(QMainWindow):
         mod: install immediately if the archive is already on disk, else open its
         download page and arm a folder watcher that auto-installs when the
         browser download arrives. `items` =
-        [(mod_name, domain, mod_id, file_id, filename), …]."""
+        [(mod_name, domain, mod_id, file_id, filename, installed_meta), …]."""
         import threading
         from gui_qt.safe_emit import safe_emit
 
@@ -5528,7 +5537,7 @@ class MainWindow(QMainWindow):
             # shared when several items point at the same mod.
             files_cache: dict = {}
             enriched = []
-            for nm, domain, mod_id, file_id, filename in items:
+            for nm, domain, mod_id, file_id, filename, installed_meta in items:
                 f = None
                 key = (domain, int(mod_id or 0))
                 if api is not None:
@@ -5547,7 +5556,7 @@ class MainWindow(QMainWindow):
                             f"({exc}); archive detection may be less reliable.")
                 if f is None:
                     f = _F(int(file_id or 0), filename or "")
-                enriched.append((nm, domain, mod_id, file_id, f))
+                enriched.append((nm, domain, mod_id, file_id, f, installed_meta))
             safe_emit(self._reinstall_manual_ready, enriched)
 
         threading.Thread(target=_prep, daemon=True,
@@ -5557,22 +5566,26 @@ class MainWindow(QMainWindow):
         """UI thread: file metadata resolved - run each mod through the shared
         start_manual_install flow (skip the browser when the archive is already
         downloaded, else open its download page + watch the download folders).
-        `enriched` = [(mod_name, domain, mod_id, file_id, NexusModFile-like), …]."""
+        `enriched` = [(mod_name, domain, mod_id, file_id, NexusModFile-like,
+        installed_meta), …]."""
         from Nexus.manual_download_watch import start_manual_install
+        from Nexus.nexus_meta import merge_reinstall_metadata
         from Utils.xdg import open_url
         from gui_qt.safe_emit import safe_emit
 
         api = getattr(self, "_nexus_api", None)
         opened = 0
-        for nm, domain, mod_id, file_id, f in enriched:
+        for nm, domain, mod_id, file_id, f, installed_meta in enriched:
             dl_key = self._new_dl_key()
             self._nexus_download_progress(dl_key, nm, 0, 0)  # show popup card
 
             # Helper callbacks run on the WATCHER thread - marshal via Signals.
             # (_op_log / _append_log are thread-safe.)
-            def on_archive(path, meta, _file, _nm=nm, _mid=mod_id, _key=dl_key):
+            def on_archive(path, meta, _file, _nm=nm, _mid=mod_id, _key=dl_key,
+                           _installed=installed_meta):
                 if not self._claim_app_manual_watch(_mid, _key):
                     return
+                meta = merge_reinstall_metadata(meta, _installed)
                 safe_emit(self._reinstall_manual_found,
                           _nm, str(path), meta, _key)
 

--- a/tests/test_reinstall_metadata.py
+++ b/tests/test_reinstall_metadata.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+nexus_package = types.ModuleType("Nexus")
+nexus_package.__path__ = [str(REPO_ROOT / "src" / "Nexus")]
+sys.modules.setdefault("Nexus", nexus_package)
+
+from Nexus import nexus_meta
+from Utils.mod_install import stage_file_list
+
+
+class ReinstallMetadataTests(unittest.TestCase):
+    def test_root_collection_layout_survives_reinstall(self):
+        installed = nexus_meta.NexusModMeta(
+            game_domain="examplegame",
+            mod_id=42,
+            file_id=314,
+            version="1.2.3",
+            nexus_name="Example Root Package",
+            root_folder=True,
+            from_collection="example-collection",
+            has_update=True,
+            latest_file_id=999,
+        )
+        refreshed = nexus_meta.build_meta_from_download(
+            game_domain="examplegame",
+            mod_id=42,
+            file_id=314,
+            archive_name="example-root-package.zip",
+        )
+
+        reinstall_meta = nexus_meta.merge_reinstall_metadata(refreshed, installed)
+
+        self.assertTrue(reinstall_meta.root_folder)
+        self.assertEqual(reinstall_meta.from_collection, "example-collection")
+        self.assertFalse(reinstall_meta.has_update)
+        self.assertEqual(reinstall_meta.latest_file_id, 0)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            extract_root = Path(temp_dir)
+            package_root = extract_root / "ExampleRootMod"
+            scripts_dir = package_root / "Data" / "Scripts"
+            scripts_dir.mkdir(parents=True)
+            (package_root / "loader.exe").write_bytes(b"loader")
+            (package_root / "runtime.dll").write_bytes(b"runtime")
+            (scripts_dir / "example.pex").write_bytes(b"script")
+
+            staged = stage_file_list(
+                self._skyrim_install_rules(),
+                str(extract_root),
+                is_root_install=reinstall_meta.root_folder,
+            )
+
+        destinations = {destination for _source, destination, is_folder in staged
+                        if not is_folder}
+        self.assertEqual(destinations, {
+            "loader.exe",
+            "runtime.dll",
+            "Data/Scripts/example.pex",
+        })
+        self.assertNotIn("Scripts/example.pex", destinations)
+
+    @staticmethod
+    def _skyrim_install_rules():
+        return SimpleNamespace(
+            mod_folder_strip_prefixes={"data"},
+            mod_required_top_level_folders={"data", "scripts"},
+            mod_install_prefix="",
+            mod_required_file_types={".esp", ".esm", ".esl", ".exe", ".dll"},
+            mod_auto_strip_until_required=True,
+            mod_install_as_is_if_no_match=False,
+            plugin_extensions=[".esp", ".esm", ".esl"],
+            archive_extensions=[".bsa"],
+            mod_folder_strip_prefixes_post={"data"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reinstall_metadata.py
+++ b/tests/test_reinstall_metadata.py
@@ -29,6 +29,8 @@ class ReinstallMetadataTests(unittest.TestCase):
             nexus_name="Example Root Package",
             root_folder=True,
             from_collection="example-collection",
+            from_collection_bundled=True,
+            from_collection_patched=True,
             has_update=True,
             latest_file_id=999,
         )
@@ -43,6 +45,8 @@ class ReinstallMetadataTests(unittest.TestCase):
 
         self.assertTrue(reinstall_meta.root_folder)
         self.assertEqual(reinstall_meta.from_collection, "example-collection")
+        self.assertFalse(reinstall_meta.from_collection_bundled)
+        self.assertFalse(reinstall_meta.from_collection_patched)
         self.assertFalse(reinstall_meta.has_update)
         self.assertEqual(reinstall_meta.latest_file_id, 0)
 
@@ -69,6 +73,35 @@ class ReinstallMetadataTests(unittest.TestCase):
             "Data/Scripts/example.pex",
         })
         self.assertNotIn("Scripts/example.pex", destinations)
+
+    def test_local_archive_reinstall_reuses_only_stable_package_identity(self):
+        installed = nexus_meta.NexusModMeta(
+            game_domain="examplegame",
+            mod_id=42,
+            file_id=314,
+            version="1.2.3",
+            nexus_name="Example Root Package",
+            root_folder=True,
+            from_collection="example-collection",
+            endorsed=True,
+            ignore_update=True,
+            ignored_version="2.0.0",
+            missing_requirements="7:Example Requirement",
+        )
+
+        reinstall_meta = nexus_meta.merge_reinstall_metadata(None, installed)
+
+        self.assertEqual(reinstall_meta.game_domain, "examplegame")
+        self.assertEqual(reinstall_meta.mod_id, 42)
+        self.assertEqual(reinstall_meta.file_id, 314)
+        self.assertEqual(reinstall_meta.version, "1.2.3")
+        self.assertEqual(reinstall_meta.nexus_name, "Example Root Package")
+        self.assertTrue(reinstall_meta.root_folder)
+        self.assertEqual(reinstall_meta.from_collection, "example-collection")
+        self.assertFalse(reinstall_meta.endorsed)
+        self.assertFalse(reinstall_meta.ignore_update)
+        self.assertEqual(reinstall_meta.ignored_version, "")
+        self.assertEqual(reinstall_meta.missing_requirements, "")
 
     @staticmethod
     def _skyrim_install_rules():


### PR DESCRIPTION
Reinstalling an existing root package could lose its install-layout metadata. For packages containing both root files and a `Data/` directory, this could flatten paths such as `Data/Scripts/example.pex` to `Scripts/example.pex` during staging.

This adds a small metadata merge for reinstalling the same installed package. Fresh download/API metadata stays authoritative, while the existing package supplies:

- missing stable Nexus identity fields
- the `root_folder` install-layout flag
- collection ownership

Transient update state, user preferences, and one-shot collection bundle/patch flags are not copied.

The merge is used for local archives, premium redownloads, and manual/browser redownloads.

## Tests

- Added coverage for reinstalling a root collection package without flattening its embedded `Data/` directory.
- Added coverage for preserving only stable reinstall metadata.
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q src tests`
- `git diff --check a4af7a91..HEAD`
