### PR TITLE
Fix Skyrim mesh path casing on case-sensitive filesystems

### DIFF
--- a/src/Games/Bethesda/skyrim_se.py
+++ b/src/Games/Bethesda/skyrim_se.py
@@ -148,6 +148,13 @@ class SkyrimSE(Fallout_3):
         return 64
 
     @property
+    def filemap_casing_prefixes(self) -> dict[str, str]:
+        return {
+            "meshes": "lower",
+            "data/meshes": "lower",
+        }
+
+    @property
     def filemap_casing_pins(self) -> dict[str, str]:
         return {
             "hudmoviebaseinstance":    "HUDMovieBaseInstance",

--- a/src/Games/base_game.py
+++ b/src/Games/base_game.py
@@ -661,6 +661,16 @@ class BaseGame(ABC):
         return "upper"
 
     @property
+    def filemap_casing_prefixes(self) -> "dict[str, str]":
+        """Per-directory-prefix overrides for :attr:`filemap_casing`.
+
+        Keys are lowercase logical directory prefixes and values are ``upper``
+        or ``lower``.  An override applies to the named directory and every
+        directory below it, while unrelated namespaces keep the global policy.
+        """
+        return {}
+
+    @property
     def filemap_casing_pins(self) -> "dict[str, str]":
         """
         Per-folder casing overrides that win over ``filemap_casing``.

--- a/src/Utils/deploy_pipeline.py
+++ b/src/Utils/deploy_pipeline.py
@@ -448,6 +448,8 @@ def _build_filemap_for_game(game, profile, *, log_fn: LogFn,
                 exclude_dirs=getattr(game, "filemap_exclude_dirs", None) or None,
                 normalize_folder_case=norm_case,
                 filemap_casing=getattr(game, "filemap_casing", "upper"),
+                filemap_casing_prefixes=getattr(
+                    game, "filemap_casing_prefixes", None),
                 filemap_casing_pins=getattr(game, "filemap_casing_pins", None),
                 conflict_key_fn=conflict_key_fn,
                 root_folder_mods=rf_mods or None,

--- a/src/Utils/deploy_root.py
+++ b/src/Utils/deploy_root.py
@@ -90,16 +90,17 @@ def deploy_root_folder(
     tasks: list[tuple[Path, Path, Path, str]] = []  # (src, dst, rel, rel_posix)
     for src, rel in sources:
         dst = _resolve_root_path(game_root, rel, _dir_cache)
+        resolved_rel = dst.relative_to(game_root)
         if len(rel.parts) > 1:
             # Use the resolved (possibly case-corrected) top-level name.
-            top = dst.relative_to(game_root).parts[0]
+            top = resolved_rel.parts[0]
             pre = _top_preexisted.get(top)
             if pre is None:
                 pre = (game_root / top).exists()
                 _top_preexisted[top] = pre
             if not pre:
                 created_dirs.add(top)
-        tasks.append((src, dst, rel, str(rel).replace("\\", "/")))
+        tasks.append((src, dst, resolved_rel, resolved_rel.as_posix()))
 
     def _write_log(rels: "list[str]") -> None:
         # Files on the first line block, then a separator, then directories
@@ -276,7 +277,7 @@ def deploy_root_flagged_mods(
             continue
 
         dst = _resolve_root_path(game_root, Path(rel_str), _dir_cache)
-        rel_posix = str(Path(rel_str)).replace("\\", "/")
+        rel_posix = dst.relative_to(game_root).as_posix()
 
         # Skip if already placed by a previous call (avoid double-backup)
         if rel_posix in existing_placed_set:

--- a/src/Utils/filemap.py
+++ b/src/Utils/filemap.py
@@ -189,7 +189,7 @@ class _IncrementalState:
         "filemap_root", "sorted_keys_root", "lines_root",
         "dirty", "last_disabled_frozen",
         "casing_strategy", "dir_refcount", "ctx_variants", "canonical",
-        "dir_rewrite", "casing_ties_present", "casing_pins",
+        "dir_rewrite", "casing_ties_present", "casing_prefixes", "casing_pins",
     )
 
     def __init__(self):
@@ -229,6 +229,7 @@ class _IncrementalState:
         self.canonical: dict[tuple[str, str], str] = {}
         self.dir_rewrite: dict[str, "str | None"] = {}
         self.casing_ties_present = False
+        self.casing_prefixes: tuple[tuple[str, str], ...] = ()
         # Per-folder casing pins (lowercase segment → exact casing) applied
         # after canonical normalization; empty = no pins.  See _pin_rel_str.
         self.casing_pins: dict[str, str] = {}
@@ -271,6 +272,7 @@ class _IncrementalState:
         st.canonical = dict(self.canonical)
         st.dir_rewrite = dict(self.dir_rewrite)
         st.casing_ties_present = self.casing_ties_present
+        st.casing_prefixes = self.casing_prefixes
         st.casing_pins = self.casing_pins  # immutable per build; share
         return st
 
@@ -345,6 +347,7 @@ def _build_incr_fingerprint(
     excluded_mod_files,
     normalize_folder_case: bool,
     filemap_casing: str,
+    filemap_casing_prefixes,
     filemap_casing_pins,
     conflict_key_fn,
     root_folder_mods,
@@ -376,6 +379,7 @@ def _build_incr_fingerprint(
             for m, v in (excluded_mod_files or {}).items()
         )),
         normalize_folder_case, filemap_casing,
+        tuple(filemap_casing_prefixes or ()),
         tuple(sorted((filemap_casing_pins or {}).items())),
         conflict_key_fn is None,
         frozenset(root_folder_mods or ()),
@@ -412,6 +416,7 @@ def _build_ctx_variants(
 def _ctx_ties_present(
     ctx_variants: dict[tuple[str, str], Counter],
     strategy: str,
+    prefix_strategies: "tuple[tuple[str, str], ...]" = (),
 ) -> bool:
     """True when any ctx has ≥2 distinct variants tied on the winning score.
 
@@ -419,10 +424,12 @@ def _ctx_ties_present(
     which incremental history cannot reproduce — such profiles always take
     the full rebuild.
     """
-    prefer_lower = strategy == FILEMAP_CASING_LOWER
-    for counts in ctx_variants.values():
+    for (parent, segment), counts in ctx_variants.items():
         if len(counts) < 2:
             continue
+        context_strategy = _casing_strategy_for_context(
+            strategy, prefix_strategies, parent, segment)
+        prefer_lower = context_strategy == FILEMAP_CASING_LOWER
         scores = [_upper_count(v) for v in counts]
         best = min(scores) if prefer_lower else max(scores)
         if scores.count(best) > 1:
@@ -442,6 +449,7 @@ def _make_incr_state(
     disabled_frozen: frozenset,
     casing_strategy, dir_refcount, ctx_variants, canonical, dir_rewrite,
     casing_ties: bool,
+    casing_prefixes: "tuple[tuple[str, str], ...]",
     casing_pins: dict[str, str],
 ) -> _IncrementalState:
     """Assemble a fresh _IncrementalState from full-merge intermediates."""
@@ -470,6 +478,7 @@ def _make_incr_state(
     st.canonical = canonical
     st.dir_rewrite = dir_rewrite
     st.casing_ties_present = casing_ties
+    st.casing_prefixes = casing_prefixes
     st.casing_pins = casing_pins
     return st
 
@@ -526,10 +535,12 @@ def _casing_dir_added(
     rc[dir_str] = cur + 1
     if cur:
         return  # dir already known; variant sets unchanged
-    strategy = st.casing_strategy or FILEMAP_CASING_UPPER
+    default_strategy = st.casing_strategy or FILEMAP_CASING_UPPER
     parent = ""
     for seg in dir_str.split("/"):
         ctx = (parent, seg.lower())
+        strategy = _casing_strategy_for_context(
+            default_strategy, st.casing_prefixes, *ctx)
         counts = st.ctx_variants.get(ctx)
         if counts is None:
             counts = st.ctx_variants[ctx] = Counter()
@@ -571,11 +582,14 @@ def _casing_dir_removed(
         rc[dir_str] = cur - 1
         return
     del rc[dir_str]
-    prefer_lower = st.casing_strategy == FILEMAP_CASING_LOWER
+    default_strategy = st.casing_strategy or FILEMAP_CASING_UPPER
     ctx_deleted = False
     parent = ""
     for seg in dir_str.split("/"):
         ctx = (parent, seg.lower())
+        strategy = _casing_strategy_for_context(
+            default_strategy, st.casing_prefixes, *ctx)
+        prefer_lower = strategy == FILEMAP_CASING_LOWER
         counts = st.ctx_variants.get(ctx)
         n = counts.get(seg, 0) if counts else 0
         if n <= 0:
@@ -766,6 +780,7 @@ def _try_incremental(
             "conflict_ignore_foldernames",
             "excluded_loose_filenames", "allowed_top_level_folders",
             "excluded_mod_files", "normalize_folder_case", "filemap_casing",
+            "filemap_casing_prefixes",
             "filemap_casing_pins",
             "no_conflict_key_fn", "root_folder_mods", "root_mod_files",
             "utf8_bad",
@@ -1454,6 +1469,31 @@ _VALID_FILEMAP_CASINGS = frozenset({
 })
 
 
+def _normalize_casing_prefixes(
+    prefixes: "dict[str, str] | None",
+) -> "tuple[tuple[str, str], ...]":
+    normalized: dict[str, str] = {}
+    for raw_prefix, strategy in (prefixes or {}).items():
+        prefix = str(raw_prefix).replace("\\", "/").strip("/").lower()
+        if prefix and strategy in (FILEMAP_CASING_UPPER, FILEMAP_CASING_LOWER):
+            normalized[prefix] = strategy
+    return tuple(sorted(
+        normalized.items(), key=lambda item: (-len(item[0]), item[0])))
+
+
+def _casing_strategy_for_context(
+    default: str,
+    prefix_strategies: "tuple[tuple[str, str], ...]",
+    parent: str,
+    segment: str,
+) -> str:
+    context = parent + segment.lower()
+    for prefix, strategy in prefix_strategies:
+        if context == prefix or context.startswith(prefix + "/"):
+            return strategy
+    return default
+
+
 def _pick_canonical_segment(a: str, b: str, strategy: str = FILEMAP_CASING_UPPER) -> str:
     """Choose the folder name whose casing best matches *strategy*.
 
@@ -1494,6 +1534,7 @@ def _collect_unique_dirs(
 def _collect_canonical(
     unique_dirs: "dict[str, None] | set[str]",
     strategy: str,
+    prefix_strategies: "tuple[tuple[str, str], ...]" = (),
 ) -> dict[tuple[str, str], str]:
     """Pick the canonical casing per folder segment across *unique_dirs*.
 
@@ -1513,7 +1554,10 @@ def _collect_canonical(
             if cur is None:
                 canonical[ctx_key] = seg
             else:
-                canonical[ctx_key] = _pick_canonical_segment(cur, seg, strategy)
+                context_strategy = _casing_strategy_for_context(
+                    strategy, prefix_strategies, *ctx_key)
+                canonical[ctx_key] = _pick_canonical_segment(
+                    cur, seg, context_strategy)
             parent = parent + seg.lower() + "/"
     return canonical
 
@@ -1567,6 +1611,7 @@ def _rewrite_rel_strs(
 def _normalize_folder_cases(
     *all_files_list: dict[str, dict[str, str]],
     strategy: str = FILEMAP_CASING_UPPER,
+    prefix_strategies: "tuple[tuple[str, str], ...]" = (),
 ) -> None:
     """Normalize folder name casing across all mods in-place.
 
@@ -1588,7 +1633,7 @@ def _normalize_folder_cases(
     unique_dirs = _collect_unique_dirs(*all_files_list)
     if not unique_dirs:
         return
-    canonical = _collect_canonical(unique_dirs, strategy)
+    canonical = _collect_canonical(unique_dirs, strategy, prefix_strategies)
     if not canonical:
         return
     dir_rewrite = _apply_canonical(canonical, unique_dirs)
@@ -1706,6 +1751,7 @@ def canonicalize_dir_casing(
     rel_paths: "list[str]",
     strategy: str = FILEMAP_CASING_UPPER,
     pins: "dict[str, str] | None" = None,
+    casing_prefixes: "dict[str, str] | None" = None,
 ) -> "dict[str, str]":
     """Map each rel path to the same path with case-variant FOLDER segments
     unified to one canonical casing. Filenames are never touched.
@@ -1727,8 +1773,9 @@ def canonicalize_dir_casing(
         slash = rel.rfind("/")
         if slash >= 0:
             unique_dirs[rel[:slash]] = None
+    prefix_strategies = _normalize_casing_prefixes(casing_prefixes)
     dir_rewrite = _apply_canonical(
-        _collect_canonical(unique_dirs, strategy), unique_dirs)
+        _collect_canonical(unique_dirs, strategy, prefix_strategies), unique_dirs)
     out: dict[str, str] = {}
     for rel in rel_paths:
         new = rel
@@ -2520,6 +2567,7 @@ def build_filemap(
     excluded_mod_files: dict[str, set[str]] | None = None,
     normalize_folder_case: bool = True,
     filemap_casing: str = FILEMAP_CASING_UPPER,
+    filemap_casing_prefixes: dict[str, str] | None = None,
     filemap_casing_pins: dict[str, str] | None = None,
     conflict_key_fn: "Callable[[str, str], str] | None" = None,
     exclude_dirs: frozenset[str] | None = None,
@@ -2575,6 +2623,10 @@ def build_filemap(
     (filemap_root.txt) instead of the Data one.  Exclusions win over root tags;
     whole-mod root flags make per-file tags redundant.
 
+    filemap_casing_prefixes — optional logical directory prefixes whose
+    canonical casing strategy differs from filemap_casing. Prefix matching is
+    case-insensitive and applies to the named directory and its descendants.
+
     Returns:
         (count, conflict_map, overrides, overridden_by)
     """
@@ -2583,6 +2635,7 @@ def build_filemap(
         {k.lower(): v for k, v in filemap_casing_pins.items()}
         if filemap_casing_pins else {}
     )
+    _casing_prefixes = _normalize_casing_prefixes(filemap_casing_prefixes)
 
     # Per-mod root-tagged rel_keys — frozen once for O(1) merge-loop membership.
     _root_files: dict[str, frozenset[str]] = {
@@ -2641,6 +2694,7 @@ def build_filemap(
                 conflict_ignore_foldernames,
                 excluded_loose_filenames, allowed_top_level_folders,
                 excluded_mod_files, normalize_folder_case, filemap_casing,
+                _casing_prefixes,
                 _pins, conflict_key_fn, root_folder_mods, _root_files,
                 _utf8_bad,
             )
@@ -2977,9 +3031,11 @@ def build_filemap(
                         if _sl2 >= 0:
                             _cas_refcount[_rs2[:_sl2]] += 1
                 _cas_ctxv = _build_ctx_variants(_udirs)
-                _cas_ties = _ctx_ties_present(_cas_ctxv, _strategy)
+                _cas_ties = _ctx_ties_present(
+                    _cas_ctxv, _strategy, _casing_prefixes)
             if _udirs:
-                _canon = _collect_canonical(_udirs, _strategy)
+                _canon = _collect_canonical(
+                    _udirs, _strategy, _casing_prefixes)
                 if _canon:
                     _drw = _apply_canonical(_canon, _udirs)
                     _rewrite_rel_strs(_drw, _norm_normal, _norm_root)
@@ -3024,7 +3080,7 @@ def build_filemap(
             filemap_root, skeys_r, lines_r,
             _disabled_frozen,
             _cas_strategy, _cas_refcount, _cas_ctxv, _cas_canon, _cas_drw,
-            _cas_ties, _pins,
+            _cas_ties, _casing_prefixes, _pins,
         ))
         _incr_stats["full"] += 1
         if _cas_ties and log_fn is not None:

--- a/src/Utils/mod_install.py
+++ b/src/Utils/mod_install.py
@@ -230,7 +230,8 @@ def _merge_case_variant_dirs(file_list, game, log_fn):
     mapping = canonicalize_dir_casing(
         rels,
         getattr(game, "filemap_casing", "upper") or "upper",
-        getattr(game, "filemap_casing_pins", None))
+        getattr(game, "filemap_casing_pins", None),
+        getattr(game, "filemap_casing_prefixes", None))
     merged = {r.rsplit("/", 1)[0] for r, n in mapping.items() if r != n and "/" in r}
     if not merged:
         return file_list

--- a/tests/test_skyrim_case_sensitive_deploy.py
+++ b/tests/test_skyrim_case_sensitive_deploy.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import inspect
+import pickle
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+if "msgpack" not in sys.modules:
+    msgpack = types.ModuleType("msgpack")
+    msgpack.pack = lambda value, stream, use_bin_type=True: pickle.dump(value, stream)
+    msgpack.unpack = lambda stream, raw=False: pickle.load(stream)
+    sys.modules["msgpack"] = msgpack
+
+from Games.Bethesda.skyrim_se import SkyrimSE
+from Utils.deploy_shared import LinkMode
+from Utils.deploy_root import deploy_root_flagged_mods, restore_root_folder
+from Utils.deploy_standard import deploy_filemap
+from Utils.filemap import build_filemap
+
+
+class SkyrimCaseSensitiveDeployTests(unittest.TestCase):
+    def test_empty_destination_uses_lowercase_source_variant(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir, _filemap = self._deploy_fixture(root)
+
+            self.assertTrue((data_dir / self.third_person_path()).is_symlink())
+            self.assertTrue((data_dir / self.first_person_path()).is_symlink())
+            self.assertFalse((data_dir / "Meshes").exists())
+
+    def test_existing_lowercase_hierarchy_is_reused(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            existing = root / "Data" / "meshes" / "actors" / "character"
+            existing.mkdir(parents=True)
+
+            data_dir, _filemap = self._deploy_fixture(root)
+
+            self.assertTrue((data_dir / self.third_person_path()).is_symlink())
+            self.assertTrue((data_dir / self.first_person_path()).is_symlink())
+            self.assertFalse((data_dir / "Meshes").exists())
+
+    def test_existing_differently_cased_hierarchy_is_reused(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            mixed_root = root / "Data" / "MeShEs" / "AcToRs" / "ChArAcTeR"
+            (mixed_root / "BeHaViOrS").mkdir(parents=True)
+            (mixed_root / "_1sTpErSoN" / "BeHaViOrS").mkdir(parents=True)
+
+            data_dir, _filemap = self._deploy_fixture(root)
+
+            self.assertTrue((mixed_root / "BeHaViOrS" / "0_master.hkx").is_symlink())
+            self.assertTrue((mixed_root / "_1sTpErSoN" / "BeHaViOrS"
+                             / "0_master.hkx").is_symlink())
+            self.assertFalse((data_dir / "meshes").exists())
+            self.assertFalse((data_dir / "Meshes").exists())
+
+    def test_fixture_filesystem_distinguishes_case_variants(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            upper = root / "Meshes"
+            lower = root / "meshes"
+            upper.mkdir()
+            lower.mkdir()
+
+            self.assertNotEqual(upper.stat().st_ino, lower.stat().st_ino)
+
+    def test_lower_policy_preserves_case_insensitive_file_identity(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _upper_data, upper_filemap = self._deploy_fixture(
+                root / "upper", casing="upper")
+            _lower_data, lower_filemap = self._deploy_fixture(
+                root / "lower", casing="lower")
+
+            upper_identity = self._casefolded_filemap(upper_filemap)
+            lower_identity = self._casefolded_filemap(lower_filemap)
+
+            self.assertEqual(lower_identity, upper_identity)
+            self.assertIn(self.third_person_path().as_posix().lower(), lower_identity)
+            self.assertIn(self.first_person_path().as_posix().lower(), lower_identity)
+
+    def test_mesh_policy_does_not_lowercase_scripts(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            profile = root / "profile"
+            staging = profile / "mods"
+            self._write_mod_file(staging, "Upper Scripts", "Scripts/example.pex")
+            self._write_mod_file(staging, "Lower Scripts", "scripts/other.pex")
+            filemap = self._build_skyrim_filemap(
+                profile, ["Upper Scripts", "Lower Scripts"])
+
+            data_dir = root / "Data"
+            deploy_filemap(filemap, data_dir, staging, mode=LinkMode.SYMLINK)
+
+            self.assertTrue((data_dir / "Scripts" / "example.pex").is_symlink())
+            self.assertTrue((data_dir / "Scripts" / "other.pex").is_symlink())
+            self.assertFalse((data_dir / "scripts").exists())
+
+    def test_normal_and_root_scripts_share_uppercase_destination(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            profile = root / "profile"
+            staging = profile / "mods"
+            self._write_mod_file(staging, "Upper Scripts", "Scripts/example.pex")
+            self._write_mod_file(staging, "Lower Scripts", "scripts/other.pex")
+            root_source = self._write_mod_file(
+                staging, "Root Package", "Data/Scripts/root-example.pex")
+            filemap = self._build_skyrim_filemap(
+                profile,
+                ["Upper Scripts", "Lower Scripts", "Root Package"],
+                root_folder_mods={"Root Package"},
+            )
+
+            game_root = root / "game"
+            data_dir = game_root / "Data"
+            data_dir.mkdir(parents=True)
+            deploy_filemap(filemap, data_dir, staging, mode=LinkMode.SYMLINK)
+            deploy_root_flagged_mods(
+                profile / "filemap_root.txt", game_root, staging,
+                mode=LinkMode.SYMLINK, strip_prefixes={"Data"})
+
+            deployed = data_dir / "Scripts" / "root-example.pex"
+            self.assertTrue(deployed.is_symlink())
+            self.assertEqual(deployed.resolve(), root_source.resolve())
+            self.assertFalse(
+                (data_dir / "scripts" / "root-example.pex").exists())
+
+    def test_mesh_policy_leaves_other_namespaces_unchanged(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            profile = root / "profile"
+            staging = profile / "mods"
+            paths = {
+                "Textures": "example.dds",
+                "SKSE/Plugins": "example.dll",
+                "Sound": "example.wav",
+                "Interface": "example.swf",
+            }
+            mods = []
+            for authored_dir, filename in paths.items():
+                label = authored_dir.replace("/", " ")
+                upper_mod = f"Upper {label}"
+                lower_mod = f"Lower {label}"
+                self._write_mod_file(
+                    staging, upper_mod, f"{authored_dir}/{filename}")
+                self._write_mod_file(
+                    staging, lower_mod,
+                    f"{authored_dir.lower()}/other-{filename}")
+                mods.extend((upper_mod, lower_mod))
+            filemap = self._build_skyrim_filemap(profile, mods)
+
+            data_dir = root / "Data"
+            deploy_filemap(filemap, data_dir, staging, mode=LinkMode.SYMLINK)
+
+            for authored_dir, filename in paths.items():
+                self.assertTrue((data_dir / authored_dir / filename).is_symlink())
+                self.assertFalse((data_dir / authored_dir.lower()).exists())
+
+    def test_deployment_has_no_casefold_duplicate_directories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            profile = root / "profile"
+            staging = profile / "mods"
+            self._write_mod_file(
+                staging, "Lower Behavior", self.third_person_path().as_posix())
+            self._write_mod_file(
+                staging, "Upper Mesh",
+                "Meshes/Actors/Character/Behaviors/idle.hkx")
+            self._write_mod_file(staging, "Upper Scripts", "Scripts/example.pex")
+            self._write_mod_file(staging, "Lower Scripts", "scripts/other.pex")
+            filemap = self._build_skyrim_filemap(
+                profile,
+                ["Lower Behavior", "Upper Mesh", "Upper Scripts", "Lower Scripts"],
+            )
+
+            data_dir = root / "Data"
+            deploy_filemap(filemap, data_dir, staging, mode=LinkMode.SYMLINK)
+
+            directories = [data_dir]
+            directories.extend(p for p in data_dir.rglob("*") if p.is_dir())
+            for directory in directories:
+                children = [
+                    p.name.casefold() for p in directory.iterdir() if p.is_dir()
+                ]
+                self.assertEqual(len(children), len(set(children)), directory)
+
+    def test_case_variant_file_conflict_keeps_one_winner(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            profile = root / "profile"
+            staging = profile / "mods"
+            winning_source = self._write_mod_file(
+                staging, "High Priority",
+                "meshes/actors/character/behaviors/0_MASTER.hkx")
+            self._write_mod_file(
+                staging, "Low Priority",
+                "Meshes/Actors/Character/Behaviors/0_master.hkx")
+            filemap = self._build_skyrim_filemap(
+                profile, ["High Priority", "Low Priority"])
+
+            lines = filemap.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            self.assertTrue(lines[0].endswith("\tHigh Priority"))
+
+            data_dir = root / "Data"
+            deploy_filemap(filemap, data_dir, staging, mode=LinkMode.SYMLINK)
+            deployed = next(data_dir.rglob("0_MASTER.hkx"))
+            self.assertEqual(deployed.resolve(), winning_source.resolve())
+
+    def test_root_restore_handles_reused_directory_casing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            profile = root / "profile"
+            staging = profile / "mods"
+            root_folder = profile / "Root_Folder"
+            root_folder.mkdir(parents=True)
+            source = self._write_mod_file(
+                staging, "Root Package", "Data/Scripts/root-example.pex")
+            self._build_skyrim_filemap(
+                profile, ["Root Package"], root_folder_mods={"Root Package"})
+            game_root = root / "game"
+            reused_dir = game_root / "Data" / "sCrIpTs"
+            reused_dir.mkdir(parents=True)
+
+            deploy_root_flagged_mods(
+                profile / "filemap_root.txt", game_root, staging,
+                mode=LinkMode.SYMLINK, strip_prefixes={"Data"})
+            deployed = reused_dir / "root-example.pex"
+            self.assertTrue(deployed.is_symlink())
+            self.assertEqual(deployed.resolve(), source.resolve())
+
+            restore_root_folder(root_folder, game_root)
+
+            self.assertFalse(deployed.exists())
+            self.assertFalse(deployed.is_symlink())
+
+    def _deploy_fixture(self, root: Path, casing: str | None = None):
+        profile = root / "profile"
+        staging = profile / "mods"
+        (profile / "overwrite").mkdir(parents=True)
+        lower_mod = staging / "Behavior Output"
+        upper_mod = staging / "Uppercase Contributor"
+        third_person = lower_mod / self.third_person_path()
+        first_person = lower_mod / self.first_person_path()
+        upper_contributor = (
+            upper_mod / "Meshes" / "Actors" / "Character" / "_1stPerson"
+            / "Behaviors" / "idle.hkx"
+        )
+        third_person.parent.mkdir(parents=True)
+        first_person.parent.mkdir(parents=True)
+        upper_contributor.parent.mkdir(parents=True)
+        third_person.write_bytes(b"third person")
+        first_person.write_bytes(b"first person")
+        upper_contributor.write_bytes(b"upper contributor")
+
+        filemap = self._build_skyrim_filemap(
+            profile, ["Behavior Output", "Uppercase Contributor"], casing=casing)
+
+        data_dir = root / "Data"
+        deploy_filemap(filemap, data_dir, staging, mode=LinkMode.SYMLINK)
+        return data_dir, filemap
+
+    @staticmethod
+    def _write_mod_file(staging: Path, mod_name: str, relative_path: str) -> Path:
+        path = staging / mod_name / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(relative_path.encode("utf-8"))
+        return path
+
+    @staticmethod
+    def _build_skyrim_filemap(
+        profile: Path,
+        mod_names: list[str],
+        *,
+        casing: str | None = None,
+        root_folder_mods: set[str] | None = None,
+    ) -> Path:
+        (profile / "overwrite").mkdir(parents=True, exist_ok=True)
+        modlist = profile / "modlist.txt"
+        modlist.write_text(
+            "".join(f"+{name}\n" for name in mod_names), encoding="utf-8")
+        filemap = profile / "filemap.txt"
+        game = object.__new__(SkyrimSE)
+        kwargs = {
+            "normalize_folder_case": True,
+            "filemap_casing": casing or game.filemap_casing,
+            "filemap_casing_pins": game.filemap_casing_pins,
+            "root_folder_mods": root_folder_mods,
+        }
+        prefixes = getattr(game, "filemap_casing_prefixes", None)
+        if (prefixes is not None
+                and "filemap_casing_prefixes" in inspect.signature(build_filemap).parameters):
+            kwargs["filemap_casing_prefixes"] = prefixes
+        build_filemap(modlist, profile / "mods", filemap, **kwargs)
+        return filemap
+
+    @staticmethod
+    def _casefolded_filemap(filemap: Path) -> dict[str, str]:
+        return {
+            relative_path.lower(): mod_name
+            for relative_path, mod_name in (
+                line.split("\t", 1)
+                for line in filemap.read_text(encoding="utf-8").splitlines()
+            )
+        }
+
+    @staticmethod
+    def third_person_path() -> Path:
+        return Path("meshes/actors/character/behaviors/0_master.hkx")
+
+    @staticmethod
+    def first_person_path() -> Path:
+        return Path("meshes/actors/character/_1stperson/behaviors/0_master.hkx")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
On case-sensitive filesystems, Skyrim mesh paths from different mods could be deployed into separate case variants such as `Meshes/Actors/...` and `meshes/actors/...`.

Amethyst already treats those paths as the same conflict identity, but the chosen canonical spelling is also used to create the physical destination. Changing Skyrim's global preference to lowercase fixes meshes but also changes unrelated directories such as `Scripts`, `Textures`, `Sound`, `Interface`, and `SKSE`.

This keeps Skyrim's existing default casing policy and adds a lowercase override only for:

- `meshes/`
- root-map `Data/meshes/`

Existing case-insensitive conflict handling is unchanged. If a matching directory already exists on disk, deployment still reuses its actual spelling instead of creating a case-only sibling.

The root deployment log now records the resolved physical path as well. This keeps Deploy and Restore in sync when an existing differently-cased directory was reused.

## Tests

Added coverage for:

- empty and pre-existing mesh destination hierarchies
- mixed-case existing directories
- no casefold-equivalent directory siblings
- case-insensitive conflict winner selection
- keeping `Scripts`, `Textures`, `Sound`, `Interface`, and `SKSE` on the default policy
- normal and root `Scripts` deployment sharing the same destination
- restoring a root file deployed through a differently-cased directory

Validation:

- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q src tests`
- `git diff --check a4af7a91..HEAD`
