### PR TITLE
Fix deploy type showing up raw in share-code preview

### DIFF
--- a/src/gui_qt/custom_game_view.py
+++ b/src/gui_qt/custom_game_view.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import io
 import threading
 
-from PySide6.QtCore import Qt, Signal, QObject, QT_TRANSLATE_NOOP
+from PySide6.QtCore import Qt, Signal, QObject, QT_TRANSLATE_NOOP, QCoreApplication
 from PySide6.QtGui import QFont
 
 from gui_qt.wheel_guard import no_wheel
@@ -66,6 +66,18 @@ _DEPLOY_OPTIONS = [
      "Binaries/Win64/, DLLs → Binaries/Win64/. Same routing as Hogwarts "
      "Legacy / Oblivion Remastered."),
 ]
+
+_DEPLOY_LABEL_BY_VALUE = {value: label for label, value, _ in _DEPLOY_OPTIONS}
+
+
+def deploy_type_display(deploy_type: str) -> str:
+    """Localized deploy-type label for UI display."""
+    value = (deploy_type or "").strip().lower()
+    label = _DEPLOY_LABEL_BY_VALUE.get(value)
+    if label is None:
+        return value
+    return QCoreApplication.translate("CustomGameView", label)
+
 
 # Display-label ↔ stored-value mapping for the filemap_casing dropdown. Labels
 # translated at display time; the combo carries `value` as item-data so the

--- a/src/gui_qt/share_code_overlay.py
+++ b/src/gui_qt/share_code_overlay.py
@@ -19,6 +19,7 @@ from PySide6.QtWidgets import (
     QWidget, QHBoxLayout, QLabel, QPushButton, QPlainTextEdit,
 )
 
+from gui_qt.custom_game_view import deploy_type_display
 from gui_qt.overlay_base import OverlayBase
 from gui_qt.theme_qt import active_palette, _c
 
@@ -322,7 +323,7 @@ class CustomGameImportOverlay(_CodeOverlayBase):
         exe = (defn.get("exe_name") or "").strip()
         if exe:
             parts.append(exe)
-        dep = (defn.get("deploy_type") or "").strip()
+        dep = deploy_type_display(defn.get("deploy_type"))
         if dep:
             parts.append(self.tr("{0} deploy").format(dep))
         self._preview.setText("  —  ".join(parts))


### PR DESCRIPTION
In Define Custom Game, the deploy method options (Standard / Root / UE5) translate fine on their own.

The problem was the Import game preview. It built the deploy bit from the raw `deploy_type` value in the JSON (`standard`, `root`, `ue5`) instead of the label you'd actually see in the UI. So you'd get stuff like:

`Hogwarts Legacy — HogwartsLegacy.exe — standard deploy`

In English that's mostly annoying casing. In other languages it's worse, the `{0} deploy` string gets translated, but {0} was still the raw key. For example in pt-BR (where the template becomes `Deploy {0}`) you'd see `Deploy standard` instead of `Deploy Padrão.`

This PR fixes that by routing `deploy_type` through a small helper that reuses the same labels as the radio buttons. Works for any locale. No need to add separate translation entries for each deploy type.

Stored values and share codes are unchanged, only the preview text is different.