### PR TITLE
Add advanced Nexus search: tags, language, size/downloads/endorsements, content options

### DIFF
--- a/src/Nexus/nexus_api.py
+++ b/src/Nexus/nexus_api.py
@@ -44,6 +44,14 @@ from version import __version__
 
 API_BASE = "https://api.nexusmods.com/v1"
 GRAPHQL_BASE = "https://api.nexusmods.com/v2/graphql"
+# The website's own mod-browser talks to this host, not GRAPHQL_BASE. Same
+# ModsFilter schema, but GRAPHQL_BASE silently no-ops the `tag` filter (parses
+# fine, matches nothing - confirmed by testing a tag id attached to a mod that
+# GRAPHQL_BASE still refused to return). Used only for the public mods-listing
+# queries (get_top_mods/search_mods*/get_trending_mods_graphql); everything
+# auth-gated (tracked/endorsed, downloads, collections, mutations) stays on
+# GRAPHQL_BASE, which is proven to work with the OAuth session.
+GRAPHQL_SEARCH_BASE = "https://api-router.nexusmods.com/graphql"
 V3_BASE = "https://api.nexusmods.com/v3"
 APP_NAME = "amethyst"
 APP_VERSION = __version__
@@ -124,6 +132,48 @@ class NexusCategory:
     category_id: int
     name: str
     parent_category: int | None = None  # None = top-level
+
+
+@dataclass
+class NexusTag:
+    """A mod tag (as offered by the site's Tags include/exclude picker)."""
+    tag_id: int
+    name: str
+    adult: bool = False
+
+
+@dataclass
+class NexusSearchFilters:
+    """Advanced ModsFilter fields layered on top of category/domain/query.
+
+    tag_includes/tag_excludes are ANDed together (a mod must carry every
+    included tag and none of the excluded ones) - each tag name becomes its
+    own ModsFilter clause since the schema has no native "one of" list op for
+    mixed EQUALS/NOT_EQUALS conditions on the same field.
+    """
+    tag_includes: tuple[str, ...] = ()
+    tag_excludes: tuple[str, ...] = ()
+    languages: tuple[str, ...] = ()   # OR'd together - a mod matching ANY selected language
+    hide_translations: bool = False   # site's "Hide translations" = exclude the Translation tag
+    min_file_size_kb: int | None = None
+    max_file_size_kb: int | None = None
+    min_downloads: int | None = None
+    max_downloads: int | None = None
+    min_endorsements: int | None = None
+    max_endorsements: int | None = None
+    adult: bool | None = None  # None = no filter, True = adult only, False = exclude adult
+    # Site's "Content Options" box, beyond adult.
+    supports_vortex: bool | None = None
+    has_updated: bool = False
+    # Site's "Search Parameters" box. title_contains overlaps with the browse
+    # bar's Name-mode search (both end up as `name` WILDCARD clauses, ANDed -
+    # narrows further rather than conflicting); description/author/uploader
+    # have no other UI path in today - not exact-match (unlike the Author-mode
+    # browse search, which is EQUALS on `uploader`).
+    title_contains: str | None = None
+    description_contains: str | None = None
+    author_contains: str | None = None
+    uploader_contains: str | None = None
 
 
 @dataclass
@@ -821,23 +871,26 @@ class NexusAPI:
 
     def _post_graphql(self, query: str, variables: dict | None = None,
                       op: str = "GraphQL",
-                      retries: int = _MAX_RETRIES) -> requests.Response:
-        """POST to the GraphQL v2 API (OAuth refresh + 429 retry); returns the raw response."""
+                      retries: int = _MAX_RETRIES,
+                      base_url: str = GRAPHQL_BASE) -> requests.Response:
+        """POST to a Nexus GraphQL endpoint (OAuth refresh + 429 retry); returns
+        the raw response. Pass base_url=GRAPHQL_SEARCH_BASE for the public
+        mods-listing queries (see the constant's docstring for why)."""
         self._refresh_oauth_if_needed()
         payload: dict[str, Any] = {"query": query}
         if variables is not None:
             payload["variables"] = variables
         for attempt in range(retries):
             try:
-                resp = self._session.post(GRAPHQL_BASE, json=payload,
+                resp = self._session.post(base_url, json=payload,
                                           timeout=self._timeout)
             except requests.ConnectionError as exc:
                 raise NexusAPIError(
-                    f"Connection failed: {exc}", url=GRAPHQL_BASE) from exc
+                    f"Connection failed: {exc}", url=base_url) from exc
             except requests.Timeout as exc:
                 raise NexusAPIError(
                     f"Request timed out after {self._timeout}s",
-                    url=GRAPHQL_BASE) from exc
+                    url=base_url) from exc
 
             self._update_rate_limits(resp)
             self._log_response("POST", op, resp)
@@ -852,7 +905,7 @@ class NexusAPI:
 
             return resp
 
-        raise RateLimitError(GRAPHQL_BASE)
+        raise RateLimitError(base_url)
 
     @property
     def rate_limits(self) -> NexusRateLimits:
@@ -1003,28 +1056,134 @@ class NexusAPI:
             ))
         return result
 
+    def get_game_tags(self, game_domain: str) -> list[NexusTag]:
+        """Return the tags offered for a game's mods (backs the Tags
+        include/exclude picker). Uses GRAPHQL_BASE, and specifically the
+        `legacyTags` query - NOT `tags`, which despite the more obvious name
+        only returns a couple dozen high-level meta tags (ids in the low
+        double digits). `legacyTags` returns the real, full vocabulary mods
+        are actually tagged with (confirmed against live per-mod `tags{}`
+        data: e.g. id 4532 "Version 1.6 Compatible" appears in both; ~140
+        entries for Stardew Valley vs. 23 from `tags`)."""
+        game_id = self._resolve_game_id(game_domain)
+        if not game_id:
+            return []
+        query = """
+        query GameLegacyTags($gameId: ID) {
+            legacyTags(gameId: $gameId) {
+                id
+                name
+            }
+        }
+        """
+        # legacyTags' gameId arg is ID, not Int (unlike tags()/modFiles()) -
+        # the server 400s on a bare int variable, so stringify it.
+        variables = {"gameId": str(game_id)}
+        try:
+            resp = self._post_graphql(query, variables, op="GraphQL gameTags")
+            if not resp.ok:
+                return []
+            data = resp.json()
+            if "errors" in data:
+                return []
+            nodes = data.get("data", {}).get("legacyTags", []) or []
+        except Exception:
+            return []
+        result: list[NexusTag] = []
+        for n in nodes:
+            try:
+                tag_id = int(n.get("id") or 0)
+            except (TypeError, ValueError):
+                tag_id = 0
+            name = (n.get("name") or "").strip()
+            if not name:
+                continue
+            result.append(NexusTag(tag_id=tag_id, name=name))
+        return result
+
     @staticmethod
+    def _advanced_filter_clauses(extra: "NexusSearchFilters | None") -> list[dict]:
+        """One ModsFilter clause dict per NexusSearchFilters condition.
+
+        Each tag name is its own clause (see NexusSearchFilters docstring for
+        why); size/downloads/endorsements are GTE/LTE on the numeric fields.
+        Multiple languages are OR'd (any match) inside one sub-clause - unlike
+        tags, a flat multi-entry `languageName` list is ANDed by the server
+        (confirmed live: two languages in one list clause matches nothing),
+        so "any of" needs an explicit op:OR the way multi-category does.
+        """
+        if not extra:
+            return []
+        clauses: list[dict] = []
+        for name in extra.tag_includes:
+            clauses.append({"tag": [{"value": name, "op": "EQUALS"}]})
+        for name in extra.tag_excludes:
+            clauses.append({"tag": [{"value": name, "op": "NOT_EQUALS"}]})
+        if extra.hide_translations:
+            clauses.append({"tag": [{"value": "Translation", "op": "NOT_EQUALS"}]})
+        if len(extra.languages) == 1:
+            clauses.append({"languageName": [{"value": extra.languages[0], "op": "EQUALS"}]})
+        elif len(extra.languages) > 1:
+            clauses.append({
+                "op": "OR",
+                "filter": [{"languageName": [{"value": lang, "op": "EQUALS"}]}
+                          for lang in extra.languages],
+            })
+        if extra.min_file_size_kb:
+            clauses.append({"fileSize": [{"value": extra.min_file_size_kb, "op": "GTE"}]})
+        if extra.max_file_size_kb:
+            clauses.append({"fileSize": [{"value": extra.max_file_size_kb, "op": "LTE"}]})
+        if extra.min_downloads:
+            clauses.append({"downloads": [{"value": extra.min_downloads, "op": "GTE"}]})
+        if extra.max_downloads:
+            clauses.append({"downloads": [{"value": extra.max_downloads, "op": "LTE"}]})
+        if extra.min_endorsements:
+            clauses.append({"endorsements": [{"value": extra.min_endorsements, "op": "GTE"}]})
+        if extra.max_endorsements:
+            clauses.append({"endorsements": [{"value": extra.max_endorsements, "op": "LTE"}]})
+        if extra.adult is not None:
+            clauses.append({"adultContent": [{"value": extra.adult}]})
+        if extra.supports_vortex is not None:
+            clauses.append({"supportsVortex": [{"value": extra.supports_vortex}]})
+        if extra.has_updated:
+            clauses.append({"hasUpdated": [{"value": True}]})
+        # WILDCARD (substring on the raw value) needs >=2 chars, same guard
+        # _search_mods_by_field uses for the browse bar's name search.
+        for field_name, value, op in (
+            ("name", extra.title_contains, "WILDCARD"),
+            ("author", extra.author_contains, "WILDCARD"),
+            ("uploader", extra.uploader_contains, "WILDCARD"),
+        ):
+            value = (value or "").strip()
+            if len(value) >= 2:
+                clauses.append({field_name: [{"value": value, "op": op}]})
+        # description has no WILDCARD op (server rejects it - MATCHES only,
+        # confirmed live); MATCHES still does substring-ish text matching.
+        desc = (extra.description_contains or "").strip()
+        if len(desc) >= 2:
+            clauses.append({"description": [{"value": desc, "op": "MATCHES"}]})
+        return clauses
+
+    @classmethod
     def _build_mods_filter(
-        game_domain: str, category_names: list[str] | None = None
+        cls, game_domain: str, category_names: list[str] | None = None,
+        extra: "NexusSearchFilters | None" = None,
     ) -> dict:
-        """Build a ModsFilter dict, optionally restricting to specific category names."""
-        base: dict = {"gameDomainName": {"value": game_domain}}
-        if not category_names:
-            return base
-        if len(category_names) == 1:
-            base["categoryName"] = {"value": category_names[0]}
-            return base
-        # Multiple categories: AND(domain, OR(cat1, cat2, ...))
-        return {
-            "op": "AND",
-            "filter": [
-                {"gameDomainName": {"value": game_domain}},
-                {
+        """Build a ModsFilter dict: gameDomainName AND category(ies) AND any
+        advanced *extra* conditions. Always returns the {op: AND, filter: […]}
+        shape (even for a single clause) so every caller can unconditionally
+        append more clauses to base_filter["filter"]."""
+        clauses: list[dict] = [{"gameDomainName": {"value": game_domain}}]
+        if category_names:
+            if len(category_names) == 1:
+                clauses.append({"categoryName": {"value": category_names[0]}})
+            else:
+                clauses.append({
                     "op": "OR",
                     "filter": [{"categoryName": {"value": n}} for n in category_names],
-                },
-            ],
-        }
+                })
+        clauses.extend(cls._advanced_filter_clauses(extra))
+        return {"op": "AND", "filter": clauses}
 
     # -- Mods ---------------------------------------------------------------
 
@@ -1093,25 +1252,17 @@ class NexusAPI:
         count: int = 20,
         offset: int = 0,
         category_names: list[str] | None = None,
+        filters: "NexusSearchFilters | None" = None,
     ) -> list[NexusModInfo]:
         """
         Fetch trending mods via GraphQL: mods published in the last 7 days,
         sorted by endorsements (highest first).
         """
         seven_days_ago = int(time.time()) - (7 * 24 * 60 * 60)
-        base_filter = self._build_mods_filter(game_domain, category_names)
-        if "filter" in base_filter:
-            base_filter["filter"].append({
-                "createdAt": [{"value": str(seven_days_ago), "op": "GTE"}],
-            })
-        else:
-            base_filter = {
-                "op": "AND",
-                "filter": [
-                    base_filter,
-                    {"createdAt": [{"value": str(seven_days_ago), "op": "GTE"}]},
-                ],
-            }
+        base_filter = self._build_mods_filter(game_domain, category_names, extra=filters)
+        base_filter["filter"].append({
+            "createdAt": [{"value": str(seven_days_ago), "op": "GTE"}],
+        })
         query = """
         query TrendingMods($filter: ModsFilter, $count: Int, $offset: Int) {
             mods(
@@ -1147,7 +1298,8 @@ class NexusAPI:
         }
         try:
             resp = self._post_graphql(query, variables,
-                                      op="GraphQL trendingMods")
+                                      op="GraphQL trendingMods",
+                                      base_url=GRAPHQL_SEARCH_BASE)
             if not resp.ok:
                 raise NexusAPIError(
                     f"GraphQL trending query failed: {resp.status_code}",
@@ -2127,6 +2279,7 @@ class NexusAPI:
         category_names: list[str] | None = None,
         created_since_days: int | None = None,
         sort_key: str = "downloads",
+        filters: "NexusSearchFilters | None" = None,
     ) -> list[NexusModInfo]:
         """
         Fetch top mods for a game via the GraphQL v2 API.
@@ -2135,21 +2288,16 @@ class NexusAPI:
         "downloads" (default), "endorsements", "createdAt", "updatedAt".
         Pass category_names to restrict results to specific categories.
         Pass created_since_days to restrict to mods uploaded within the last N days
-        (None = all time).
+        (None = all time). Pass filters for tag/language/size/downloads/
+        endorsements/adult conditions (see NexusSearchFilters).
         """
         if sort_key not in self._TOP_MODS_SORT_KEYS:
             sort_key = "downloads"
-        base_filter = self._build_mods_filter(game_domain, category_names)
+        base_filter = self._build_mods_filter(game_domain, category_names, extra=filters)
         if created_since_days is not None and created_since_days > 0:
             cutoff = int(time.time()) - (created_since_days * 24 * 60 * 60)
-            date_clause = {"createdAt": [{"value": str(cutoff), "op": "GTE"}]}
-            if "filter" in base_filter:
-                base_filter["filter"].append(date_clause)
-            else:
-                base_filter = {
-                    "op": "AND",
-                    "filter": [base_filter, date_clause],
-                }
+            base_filter["filter"].append(
+                {"createdAt": [{"value": str(cutoff), "op": "GTE"}]})
         query = f"""
         query TopMods($filter: ModsFilter, $count: Int, $offset: Int) {{
             mods(
@@ -2184,7 +2332,8 @@ class NexusAPI:
             "offset": offset,
         }
         try:
-            resp = self._post_graphql(query, variables, op="GraphQL topMods")
+            resp = self._post_graphql(query, variables, op="GraphQL topMods",
+                                      base_url=GRAPHQL_SEARCH_BASE)
             if not resp.ok:
                 raise NexusAPIError(
                     f"GraphQL top-mods query failed: {resp.status_code}",
@@ -2228,6 +2377,7 @@ class NexusAPI:
         self, game_domain: str, query_text: str, count: int = 10, offset: int = 0,
         category_names: list[str] | None = None,
         sort_key: str = "downloads",
+        filters: "NexusSearchFilters | None" = None,
     ) -> list[NexusModInfo]:
         """
         Search mods by name for a game via the GraphQL v2 API.
@@ -2237,12 +2387,13 @@ class NexusAPI:
         """
         return self._search_mods_by_field(
             "name", game_domain, query_text, count=count, offset=offset,
-            category_names=category_names, sort_key=sort_key)
+            category_names=category_names, sort_key=sort_key, filters=filters)
 
     def search_mods_by_uploader_id(
         self, game_domain: str, uploader_id: int, count: int = 10, offset: int = 0,
         category_names: list[str] | None = None,
         sort_key: str = "downloads",
+        filters: "NexusSearchFilters | None" = None,
     ) -> list[NexusModInfo]:
         """
         List a game's mods by the uploader's stable account id (GraphQL
@@ -2260,12 +2411,13 @@ class NexusAPI:
         cond = {"uploaderId": [{"value": str(uploader_id)}]}
         return self._search_mods_filtered(
             game_domain, cond, count=count, offset=offset,
-            category_names=category_names, sort_key=sort_key)
+            category_names=category_names, sort_key=sort_key, filters=filters)
 
     def search_mods_by_author(
         self, game_domain: str, author: str, count: int = 10, offset: int = 0,
         category_names: list[str] | None = None,
         sort_key: str = "downloads",
+        filters: "NexusSearchFilters | None" = None,
     ) -> list[NexusModInfo]:
         """
         Search a game's mods by the uploader's display name (GraphQL `uploader`
@@ -2281,12 +2433,13 @@ class NexusAPI:
         cond = {"uploader": [{"value": author}]}
         return self._search_mods_filtered(
             game_domain, cond, count=count, offset=offset,
-            category_names=category_names, sort_key=sort_key)
+            category_names=category_names, sort_key=sort_key, filters=filters)
 
     def _search_mods_by_field(
         self, field: str, game_domain: str, value: str, count: int = 10,
         offset: int = 0, category_names: list[str] | None = None,
         sort_key: str = "downloads",
+        filters: "NexusSearchFilters | None" = None,
     ) -> list[NexusModInfo]:
         """
         WILDCARD text search on a single field (used by search_mods for `name`).
@@ -2303,26 +2456,24 @@ class NexusAPI:
         return self._search_mods_filtered(
             game_domain, {field: {"value": value, "op": "WILDCARD"}},
             count=count, offset=offset, category_names=category_names,
-            sort_key=sort_key)
+            sort_key=sort_key, filters=filters)
 
     def _search_mods_filtered(
         self, game_domain: str, cond: dict, count: int = 10,
         offset: int = 0, category_names: list[str] | None = None,
         sort_key: str = "downloads",
+        filters: "NexusSearchFilters | None" = None,
     ) -> list[NexusModInfo]:
         """
         Shared GraphQL mod search: run the SearchMods query with *cond* (a
-        prebuilt ModsFilter condition) AND-ed onto the domain/category filter.
-        Keeps the query + node parsing in one place for all the search variants.
+        prebuilt ModsFilter condition) AND-ed onto the domain/category/advanced
+        filter. Keeps the query + node parsing in one place for all the search
+        variants.
         """
         if sort_key not in self._TOP_MODS_SORT_KEYS:
             sort_key = "downloads"
-        base_filter = self._build_mods_filter(game_domain, category_names)
-        if "filter" in base_filter:
-            # nested AND structure - append the condition
-            base_filter["filter"].append(cond)
-        else:
-            base_filter.update(cond)
+        base_filter = self._build_mods_filter(game_domain, category_names, extra=filters)
+        base_filter["filter"].append(cond)
         query = f"""
         query SearchMods($filter: ModsFilter, $count: Int, $offset: Int) {{
             mods(
@@ -2358,7 +2509,8 @@ class NexusAPI:
         }
         try:
             resp = self._post_graphql(query, variables,
-                                      op="GraphQL searchMods")
+                                      op="GraphQL searchMods",
+                                      base_url=GRAPHQL_SEARCH_BASE)
             if not resp.ok:
                 raise NexusAPIError(
                     f"GraphQL search query failed: {resp.status_code}",

--- a/src/gui_qt/nexus_browser_view.py
+++ b/src/gui_qt/nexus_browser_view.py
@@ -22,11 +22,11 @@ from __future__ import annotations
 
 import threading
 
-from PySide6.QtCore import Qt, QTimer, Signal, QEvent, QDate
+from PySide6.QtCore import Qt, QTimer, Signal, QEvent, QDate, QStringListModel
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QLabel, QLineEdit,
     QScrollArea, QFrame, QCheckBox, QToolButton, QMenu,
-    QSplitter,
+    QSplitter, QCompleter, QComboBox,
 )
 
 from gui_qt.theme_qt import active_palette, _c
@@ -54,6 +54,34 @@ TIME_RANGES = [
     ("Year", 365),
 ]
 SECTIONS = ["Browse", "Tracked", "Endorsed", "Trending"]
+# Common mod-translation languages on Nexus. Not exhaustive - the API doesn't
+# expose a list to query, so this is a curated set matching what shows up in
+# practice (mirrors the site's own Language Support filter roughly).
+LANGUAGES = [
+    "English", "French", "German", "Spanish", "Italian", "Polish",
+    "Portuguese", "Russian", "Chinese", "Japanese", "Korean", "Turkish",
+    "Dutch", "Czech", "Hungarian", "Swedish", "Ukrainian", "Arabic",
+    "Vietnamese", "Thai", "Indonesian",
+]
+# File Size / Downloads / Endorsements min/max dropdown presets - lifted
+# straight from the site's own filter menus (values confirmed live), not
+# invented breakpoints, so a user picking "50MB" here gets the same result
+# they'd get there.
+FILE_SIZE_PRESETS = [
+    ("1KB", 1), ("100KB", 100), ("500KB", 500), ("1MB", 1024),
+    ("50MB", 51_200), ("100MB", 102_400), ("500MB", 512_000),
+    ("1GB", 1_048_576), ("5GB", 5_242_880), ("10GB", 10_485_760),
+]
+DOWNLOADS_PRESETS = [
+    ("50", 50), ("100", 100), ("1,000", 1_000), ("5,000", 5_000),
+    ("10,000", 10_000), ("50,000", 50_000), ("100,000", 100_000),
+    ("500,000", 500_000), ("1,000,000", 1_000_000), ("5,000,000", 5_000_000),
+]
+ENDORSEMENTS_PRESETS = [
+    ("10", 10), ("50", 50), ("100", 100), ("1,000", 1_000), ("5,000", 5_000),
+    ("10,000", 10_000), ("50,000", 50_000), ("100,000", 100_000),
+    ("300,000", 300_000),
+]
 # Default "shown per page"; overridden by the footer dropdown (persisted).
 PAGE_SIZE_BROWSE = 30
 # User-selectable "shown per page" counts (footer dropdown).
@@ -66,6 +94,7 @@ class NexusBrowserView(QWidget):
 
     _results_ready = Signal(object, str, object)   # (entries, status, token)
     _cats_ready = Signal(object, str)               # (list[NexusCategory], domain)
+    _tags_ready = Signal(object, str)               # (list[NexusTag], domain)
     _premium_checked = Signal(object, object)       # (entry, is_premium|None)
     _files_ready = Signal(object, object)           # (entry, list[NexusModFile])
     _manual_files_ready = Signal(object, object)    # (entry, list[NexusModFile]|None)
@@ -105,7 +134,10 @@ class NexusBrowserView(QWidget):
         # name. Non-zero id here → the Author-mode worker uses the id path.
         self._uploader_id = 0
         self._selected_categories: list[str] = []
-        self._show_adult = self._load_show_adult()
+        # None = no adult filter (site's "neither box checked"), True = only
+        # adult, False = hidden. Persisted default mirrors the old toolbar
+        # toggle: hidden unless the user previously chose to see everything.
+        self._adult: bool | None = False if not self._load_show_adult() else None
         self._page_size_choice = self._load_page_size()
         self._entries = []
         self._cards: list[NexusModCard] = []
@@ -113,10 +145,31 @@ class NexusBrowserView(QWidget):
         self._fetch_token = 0           # guards against stale async results
         self._cats_loaded = False
 
+        # advanced search state (see Nexus.nexus_api.NexusSearchFilters)
+        self._tags_loaded = False
+        self._game_tags: list = []          # list[NexusTag] for the active domain
+        self._tag_includes: list[str] = []
+        self._tag_excludes: list[str] = []
+        self._languages: list[str] = []
+        self._hide_translations = False
+        self._min_size_kb: int | None = None
+        self._max_size_kb: int | None = None
+        self._min_downloads: int | None = None
+        self._max_downloads: int | None = None
+        self._min_endorsements: int | None = None
+        self._max_endorsements: int | None = None
+        self._supports_vortex: bool | None = None
+        self._has_updated = False
+        self._title_contains = ""
+        self._description_contains = ""
+        self._author_contains = ""
+        self._uploader_contains = ""
+
         self._thumbs = ThumbnailLoader(self)
         self._thumbs.loaded.connect(self._on_thumb)
         self._results_ready.connect(self._on_results)
         self._cats_ready.connect(self._on_cats)
+        self._tags_ready.connect(self._on_tags_ready)
         self._premium_checked.connect(self._on_premium_checked)
         self._files_ready.connect(self._on_files_ready)
         self._manual_files_ready.connect(self._on_manual_files_ready)
@@ -149,6 +202,7 @@ class NexusBrowserView(QWidget):
         self._update_section_buttons()
         self._update_browse_controls_visibility()
         self._load_categories()
+        self._load_tags()
         self._reload()
 
     # -- construction -------------------------------------------------------
@@ -165,6 +219,21 @@ class NexusBrowserView(QWidget):
         #FilterBody {{ background: {c('BG_PANEL')}; }}
         #FilterEmpty {{ color: {c('TEXT_DIM')}; font-style: italic; }}
         QScrollArea {{ background: {c('BG_PANEL')}; border: none; }}
+        #CollapsibleSection {{
+            border: 1px solid {c('BORDER')};
+            border-radius: 6px;
+            background: {c('BG_PANEL')};
+        }}
+        QToolButton#SectionToggle {{
+            background: transparent; border: none;
+            font-weight: bold; color: {c('TEXT_MAIN')};
+            padding: 2px 0;
+        }}
+        QToolButton#SectionToggle:hover,
+        QToolButton#SectionToggle:pressed,
+        QToolButton#SectionToggle:checked {{
+            background: transparent; color: {c('TEXT_MAIN')};
+        }}
         """
 
     @staticmethod
@@ -182,6 +251,172 @@ class NexusBrowserView(QWidget):
             return int(load_nexus_page_size(PAGE_SIZE_BROWSE))
         except Exception:
             return PAGE_SIZE_BROWSE
+
+    def _add_filter_section(self, host_layout: QVBoxLayout, title: str,
+                            *, expanded: bool = False):
+        """Add an openable/closable section (site parity) to *host_layout*;
+        returns its body layout to fill in."""
+        from gui_qt.collapsible_section import CollapsibleSection
+        sec = CollapsibleSection(title)
+        if expanded:
+            sec.expand()
+        body_layout = QVBoxLayout(sec.body)
+        body_layout.setContentsMargins(0, 0, 0, 0)
+        body_layout.setSpacing(4)
+        host_layout.addWidget(sec)
+        return body_layout
+
+    @staticmethod
+    def _range_combo(presets: list[tuple[str, int]], no_label: str) -> "QComboBox":
+        """A min/max dropdown: "No min"/"No max" (data=None) plus the site's
+        exact preset breakpoints (data=the raw filter value)."""
+        cb = QComboBox()
+        cb.addItem(no_label, None)
+        for label, value in presets:
+            cb.addItem(label, value)
+        return cb
+
+    def _build_advanced_search_section(self, host_layout: QVBoxLayout, p) -> None:
+        """Tags, Search Parameters, Language Support, Content Options, File
+        Size, Downloads, Endorsements - the rest of the site's filter panel,
+        each its own openable/closable section like the site's. Built once
+        (unlike Category, this doesn't get rebuilt per game); _reload() reads
+        the live widget state each fetch."""
+
+        def _tag_edit(placeholder: str) -> QLineEdit:
+            e = QLineEdit()
+            e.setPlaceholderText(placeholder)
+            completer = QCompleter([], self)
+            completer.setCaseSensitivity(Qt.CaseInsensitive)
+            completer.setFilterMode(Qt.MatchContains)
+            e.setCompleter(completer)
+            return e
+
+        # -- Tags -------------------------------------------------------
+        lay = self._add_filter_section(host_layout, self.tr("Tags"))
+        lay.addWidget(QLabel(self.tr("Includes")))
+        self._tag_include_edit = _tag_edit(self.tr("Type a tag, press Enter…"))
+        self._tag_include_edit.returnPressed.connect(
+            lambda: self._add_tag(self._tag_include_edit, include=True))
+        lay.addWidget(self._tag_include_edit)
+        self._tag_include_row = QWidget()
+        self._tag_include_flow = FlowLayout(self._tag_include_row, spacing=4)
+        lay.addWidget(self._tag_include_row)
+
+        lay.addWidget(QLabel(self.tr("Excludes")))
+        self._tag_exclude_edit = _tag_edit(self.tr("Type a tag, press Enter…"))
+        self._tag_exclude_edit.returnPressed.connect(
+            lambda: self._add_tag(self._tag_exclude_edit, include=False))
+        lay.addWidget(self._tag_exclude_edit)
+        self._tag_exclude_row = QWidget()
+        self._tag_exclude_flow = FlowLayout(self._tag_exclude_row, spacing=4)
+        lay.addWidget(self._tag_exclude_row)
+
+        # -- Search Parameters -------------------------------------------
+        # title_contains overlaps with the browse bar's search (ANDs with it
+        # rather than replacing it - see NexusSearchFilters docstring).
+        # Debounced like the numeric dropdowns below react instantly, not a
+        # separate Apply button like the site - this panel already auto-
+        # applies on pause everywhere else, so these match that convention.
+        lay = self._add_filter_section(host_layout, self.tr("Search Parameters"))
+        self._title_contains_edit = QLineEdit()
+        self._title_contains_edit.setPlaceholderText(self.tr("Title contains"))
+        lay.addWidget(self._title_contains_edit)
+        self._description_contains_edit = QLineEdit()
+        self._description_contains_edit.setPlaceholderText(self.tr("Description contains"))
+        lay.addWidget(self._description_contains_edit)
+        self._author_contains_edit = QLineEdit()
+        self._author_contains_edit.setPlaceholderText(self.tr("Author contains"))
+        lay.addWidget(self._author_contains_edit)
+        self._uploader_contains_edit = QLineEdit()
+        self._uploader_contains_edit.setPlaceholderText(self.tr("Uploader contains"))
+        lay.addWidget(self._uploader_contains_edit)
+        for edit in (self._title_contains_edit, self._description_contains_edit,
+                     self._author_contains_edit, self._uploader_contains_edit):
+            edit.textChanged.connect(self._on_advanced_text_changed)
+
+        # -- Language Support ---------------------------------------------
+        # Multi-select (OR'd - "any of these languages"), same TriStateCheckBox
+        # the category list uses, matching the site's checkbox list rather
+        # than a single-choice dropdown.
+        from gui_qt.tri_state_checkbox import TriStateCheckBox
+        lay = self._add_filter_section(host_layout, self.tr("Language Support"))
+        self._hide_translations_cb = TriStateCheckBox(
+            self.tr("Hide translations"), two_state=True)
+        self._hide_translations_cb.stateChanged.connect(
+            lambda _s: self._on_hide_translations_toggled())
+        lay.addWidget(self._hide_translations_cb)
+        self._lang_checks: list[TriStateCheckBox] = []
+        for lang in LANGUAGES:
+            cb = TriStateCheckBox(lang, two_state=True)
+            cb._lang_name = lang
+            cb.stateChanged.connect(lambda _s: self._on_language_toggled())
+            lay.addWidget(cb)
+            self._lang_checks.append(cb)
+
+        # -- Content Options ------------------------------------------------
+        # Hide/Show-only adult are mutually exclusive (site behaves the same
+        # way, even though it renders them as independent checkboxes).
+        lay = self._add_filter_section(host_layout, self.tr("Content Options"))
+        self._hide_adult_cb = TriStateCheckBox(self.tr("Hide adult content"), two_state=True)
+        self._hide_adult_cb.stateChanged.connect(lambda _s: self._on_hide_adult_toggled())
+        lay.addWidget(self._hide_adult_cb)
+        self._show_only_adult_cb = TriStateCheckBox(
+            self.tr("Show only adult content"), two_state=True)
+        self._show_only_adult_cb.stateChanged.connect(
+            lambda _s: self._on_show_only_adult_toggled())
+        lay.addWidget(self._show_only_adult_cb)
+        self._supports_vortex_cb = TriStateCheckBox(self.tr("Supported by Vortex"), two_state=True)
+        self._supports_vortex_cb.stateChanged.connect(
+            lambda _s: self._on_content_option_toggled())
+        lay.addWidget(self._supports_vortex_cb)
+        self._only_updated_cb = TriStateCheckBox(self.tr("Show only updated mods"), two_state=True)
+        self._only_updated_cb.stateChanged.connect(
+            lambda _s: self._on_content_option_toggled())
+        lay.addWidget(self._only_updated_cb)
+        self._hide_adult_cb.set_state(1 if self._adult is False else 0)
+
+        # -- File Size / Downloads / Endorsements --------------------------
+        # Dropdown presets, not free-text - lifted straight from the site's
+        # own min/max menus (verified against the live filter UI).
+        lay = self._add_filter_section(host_layout, self.tr("File Size"))
+        size_row = QHBoxLayout()
+        self._min_size_combo = self._range_combo(FILE_SIZE_PRESETS, self.tr("No min"))
+        self._max_size_combo = self._range_combo(FILE_SIZE_PRESETS, self.tr("No max"))
+        size_row.addWidget(self._min_size_combo)
+        size_row.addWidget(QLabel(self.tr("to")))
+        size_row.addWidget(self._max_size_combo)
+        lay.addLayout(size_row)
+
+        lay = self._add_filter_section(host_layout, self.tr("Downloads"))
+        dl_row = QHBoxLayout()
+        self._min_downloads_combo = self._range_combo(DOWNLOADS_PRESETS, self.tr("No min"))
+        self._max_downloads_combo = self._range_combo(DOWNLOADS_PRESETS, self.tr("No max"))
+        dl_row.addWidget(self._min_downloads_combo)
+        dl_row.addWidget(QLabel(self.tr("to")))
+        dl_row.addWidget(self._max_downloads_combo)
+        lay.addLayout(dl_row)
+
+        lay = self._add_filter_section(host_layout, self.tr("Endorsements"))
+        end_row = QHBoxLayout()
+        self._min_endorsements_combo = self._range_combo(ENDORSEMENTS_PRESETS, self.tr("No min"))
+        self._max_endorsements_combo = self._range_combo(ENDORSEMENTS_PRESETS, self.tr("No max"))
+        end_row.addWidget(self._min_endorsements_combo)
+        end_row.addWidget(QLabel(self.tr("to")))
+        end_row.addWidget(self._max_endorsements_combo)
+        lay.addLayout(end_row)
+
+        for combo in (self._min_size_combo, self._max_size_combo,
+                     self._min_downloads_combo, self._max_downloads_combo,
+                     self._min_endorsements_combo, self._max_endorsements_combo):
+            combo.currentIndexChanged.connect(lambda _i: self._apply_advanced_text_filters())
+
+        clear_btn = QToolButton()
+        clear_btn.setText(self.tr("Clear advanced filters"))
+        clear_btn.setObjectName("ActionButton")
+        clear_btn.setCursor(Qt.PointingHandCursor)
+        clear_btn.clicked.connect(self._clear_advanced_filters)
+        host_layout.addWidget(clear_btn)
 
     @staticmethod
     def _enable_hfw(w: QWidget) -> None:
@@ -211,7 +446,7 @@ class NexusBrowserView(QWidget):
         tb.setContentsMargins(10, 6, 10, 6)
 
         self._cat_toggle = QToolButton()
-        self._cat_toggle.setText(self.tr("☰ Categories"))
+        self._cat_toggle.setText(self.tr("☰ Filters"))
         self._cat_toggle.setObjectName("ActionButton")
         self._cat_toggle.setCheckable(True)
         self._cat_toggle.setChecked(True)
@@ -251,11 +486,6 @@ class NexusBrowserView(QWidget):
             actions=[(self.tr("Custom…"), self._pick_custom_time)])
         tb.addWidget(self._time_sel)
 
-        self._adult_cb = QCheckBox(self.tr("Show adult"))
-        self._adult_cb.setChecked(self._show_adult)
-        self._adult_cb.toggled.connect(self._on_adult_toggled)
-        tb.addWidget(self._adult_cb)
-
         refresh = QToolButton()
         refresh.setText(self.tr("Refresh"))
         refresh.setObjectName("ActionButton")
@@ -287,7 +517,7 @@ class NexusBrowserView(QWidget):
         cat_header.setObjectName("FilterHeader")
         chl = QHBoxLayout(cat_header)
         chl.setContentsMargins(10, 6, 8, 6)
-        cat_hdr = QLabel(self.tr("Categories"))
+        cat_hdr = QLabel(self.tr("Filters"))
         cat_hdr.setObjectName("FilterTitle")
         chl.addWidget(cat_hdr)
         chl.addStretch(1)
@@ -299,18 +529,38 @@ class NexusBrowserView(QWidget):
         self._cat_scroll = QScrollArea()
         self._cat_scroll.setWidgetResizable(True)
         self._cat_scroll.setFrameShape(QFrame.NoFrame)
+        # _cat_host holds every section, each an openable/closable
+        # CollapsibleSection like the site's own filter panel. Category is
+        # rebuilt per game (_on_cats, via _cat_layout inside its section body);
+        # the rest are built once here and never rebuilt.
         self._cat_host = QWidget()
         self._cat_host.setObjectName("FilterBody")
-        self._cat_layout = QVBoxLayout(self._cat_host)
-        self._cat_layout.setContentsMargins(10, 8, 10, 12)
+        host_layout = QVBoxLayout(self._cat_host)
+        host_layout.setContentsMargins(10, 8, 10, 12)
+        host_layout.setSpacing(6)
+        host_layout.setAlignment(Qt.AlignTop)
+
+        from gui_qt.collapsible_section import CollapsibleSection
+        cat_section = CollapsibleSection(self.tr("Category"))
+        cat_section.expand()             # open by default, matching current behaviour
+        cat_body_layout = QVBoxLayout(cat_section.body)
+        cat_body_layout.setContentsMargins(0, 0, 0, 0)
+        cat_list_host = QWidget()
+        self._cat_layout = QVBoxLayout(cat_list_host)
+        self._cat_layout.setContentsMargins(0, 0, 0, 0)
         self._cat_layout.setSpacing(3)
         self._cat_layout.setAlignment(Qt.AlignTop)
-        self._cat_scroll.setWidget(self._cat_host)
-        cv.addWidget(self._cat_scroll, 1)
+        cat_body_layout.addWidget(cat_list_host)
         self._cat_checks: list[QCheckBox] = []
         self._cat_status = QLabel(self.tr("Loading…"))
         self._cat_status.setObjectName("FilterEmpty")
         self._cat_layout.addWidget(self._cat_status)
+        host_layout.addWidget(cat_section)
+
+        self._build_advanced_search_section(host_layout, p)
+
+        self._cat_scroll.setWidget(self._cat_host)
+        cv.addWidget(self._cat_scroll, 1)
         self._cat_panel.setStyleSheet(self._filter_qss(p))
         self._body_split.addWidget(self._cat_panel)
 
@@ -520,6 +770,174 @@ class NexusBrowserView(QWidget):
         self._page = 0
         self._reload()
 
+    # -- advanced search: tags / language / size / downloads / endorsements -
+    def _load_tags(self):
+        if self._tags_loaded or not self._domain:
+            return
+        domain = self._domain
+        run_in_worker(
+            lambda: (self._api.get_game_tags(domain), domain),
+            self._tags_ready, name="nexus-tags", unpack=True,
+            error_result=([], domain))
+
+    def _on_tags_ready(self, tags, domain: str):
+        if domain != self._domain:
+            return                       # stale result from the previous domain
+        self._tags_loaded = True
+        self._game_tags = list(tags or [])
+        names = sorted({t.name for t in self._game_tags}, key=str.lower)
+        for edit in (self._tag_include_edit, self._tag_exclude_edit):
+            completer = edit.completer()
+            if completer is not None:
+                completer.setModel(QStringListModel(names, completer))
+
+    def _add_tag(self, edit: QLineEdit, include: bool):
+        typed = edit.text().strip()
+        edit.clear()
+        if not typed:
+            return
+        # Match the fetched tag list case-insensitively so the stored name is
+        # exactly what the API expects; fall back to the typed text verbatim
+        # if the tag list hasn't loaded yet or has no match.
+        name = next((t.name for t in self._game_tags
+                    if t.name.lower() == typed.lower()), typed)
+        target = self._tag_includes if include else self._tag_excludes
+        other = self._tag_excludes if include else self._tag_includes
+        if name in other:
+            other.remove(name)           # a tag can't be both included and excluded
+        if name not in target:
+            target.append(name)
+        self._rebuild_tag_chips()
+        self._page = 0
+        self._reload()
+
+    def _remove_tag(self, name: str, include: bool):
+        target = self._tag_includes if include else self._tag_excludes
+        if name in target:
+            target.remove(name)
+        self._rebuild_tag_chips()
+        self._page = 0
+        self._reload()
+
+    def _rebuild_tag_chips(self):
+        for flow, names, include in (
+            (self._tag_include_flow, self._tag_includes, True),
+            (self._tag_exclude_flow, self._tag_excludes, False),
+        ):
+            while flow.count():
+                it = flow.takeAt(0)
+                w = it.widget()
+                if w is not None:
+                    w.deleteLater()
+            for name in names:
+                chip = QToolButton()
+                chip.setText(f"{name}  ✕")
+                chip.setObjectName("ActionButton")
+                chip.setCursor(Qt.PointingHandCursor)
+                chip.setToolTip(self.tr("Remove"))
+                chip.clicked.connect(
+                    lambda _=False, n=name, inc=include: self._remove_tag(n, inc))
+                flow.addWidget(chip)
+
+    def _on_language_toggled(self):
+        self._languages = [cb._lang_name for cb in self._lang_checks if cb.state()]
+        self._page = 0
+        self._reload()
+
+    def _on_hide_translations_toggled(self):
+        self._hide_translations = bool(self._hide_translations_cb.state())
+        self._page = 0
+        self._reload()
+
+    def _on_advanced_text_changed(self, _text=None):
+        t = getattr(self, "_advanced_timer", None)
+        if t is None:
+            t = QTimer(self)
+            t.setSingleShot(True)
+            t.setInterval(600)
+            t.timeout.connect(self._apply_advanced_text_filters)
+            self._advanced_timer = t
+        t.start()
+
+    def _apply_advanced_text_filters(self):
+        self._min_size_kb = self._min_size_combo.currentData()
+        self._max_size_kb = self._max_size_combo.currentData()
+        self._min_downloads = self._min_downloads_combo.currentData()
+        self._max_downloads = self._max_downloads_combo.currentData()
+        self._min_endorsements = self._min_endorsements_combo.currentData()
+        self._max_endorsements = self._max_endorsements_combo.currentData()
+        self._title_contains = self._title_contains_edit.text().strip()
+        self._description_contains = self._description_contains_edit.text().strip()
+        self._author_contains = self._author_contains_edit.text().strip()
+        self._uploader_contains = self._uploader_contains_edit.text().strip()
+        self._page = 0
+        self._reload()
+
+    def _reset_advanced_filter_state(self):
+        """Clear tags/language/content-options/size/downloads/endorsements/
+        search-parameters without reloading - used both by the "Clear" button
+        (which does reload) and domain retargeting (which reloads once,
+        later, after everything else resets)."""
+        self._tag_includes.clear()
+        self._tag_excludes.clear()
+        self._rebuild_tag_chips()
+        self._languages = []
+        for cb in self._lang_checks:
+            cb.set_state(0)              # emit=False: no reload storm here
+        self._hide_translations = False
+        self._hide_translations_cb.set_state(0)
+        self._adult = None
+        self._hide_adult_cb.set_state(0)
+        self._show_only_adult_cb.set_state(0)
+        self._supports_vortex = None
+        self._supports_vortex_cb.set_state(0)
+        self._has_updated = False
+        self._only_updated_cb.set_state(0)
+        for combo in (self._min_size_combo, self._max_size_combo,
+                     self._min_downloads_combo, self._max_downloads_combo,
+                     self._min_endorsements_combo, self._max_endorsements_combo):
+            combo.blockSignals(True)
+            combo.setCurrentIndex(0)
+            combo.blockSignals(False)
+        self._min_size_kb = self._max_size_kb = None
+        self._min_downloads = self._max_downloads = None
+        self._min_endorsements = self._max_endorsements = None
+        for edit in (self._title_contains_edit, self._description_contains_edit,
+                     self._author_contains_edit, self._uploader_contains_edit):
+            edit.blockSignals(True)
+            edit.clear()
+            edit.blockSignals(False)
+        self._title_contains = self._description_contains = ""
+        self._author_contains = self._uploader_contains = ""
+
+    def _clear_advanced_filters(self):
+        self._reset_advanced_filter_state()
+        self._page = 0
+        self._reload()
+
+    def _current_search_filters(self):
+        """Build a NexusSearchFilters from the live advanced-search widgets."""
+        from Nexus.nexus_api import NexusSearchFilters
+        return NexusSearchFilters(
+            tag_includes=tuple(self._tag_includes),
+            tag_excludes=tuple(self._tag_excludes),
+            languages=tuple(self._languages),
+            hide_translations=self._hide_translations,
+            min_file_size_kb=self._min_size_kb,
+            max_file_size_kb=self._max_size_kb,
+            min_downloads=self._min_downloads,
+            max_downloads=self._max_downloads,
+            min_endorsements=self._min_endorsements,
+            max_endorsements=self._max_endorsements,
+            adult=self._adult,
+            supports_vortex=self._supports_vortex,
+            has_updated=self._has_updated,
+            title_contains=self._title_contains or None,
+            description_contains=self._description_contains or None,
+            author_contains=self._author_contains or None,
+            uploader_contains=self._uploader_contains or None,
+        )
+
     # -- toolbar handlers ---------------------------------------------------
     def _on_sort_changed(self, label: str):
         self._sort_key = dict(SORT_KEYS).get(label, "downloads")
@@ -570,14 +988,34 @@ class NexusBrowserView(QWidget):
         self._page = 0
         self._reload()
 
-    def _on_adult_toggled(self, on: bool):
-        self._show_adult = bool(on)
+    def _on_hide_adult_toggled(self):
+        """Hide/Show-only adult are mutually exclusive (site behaves the same
+        even though it renders them as two independent checkboxes)."""
+        on = bool(self._hide_adult_cb.state())
+        if on:
+            self._show_only_adult_cb.set_state(0)   # emit=False: no double reload
+        self._adult = False if on else None
         try:
             from Utils.ui_config import save_nexus_show_adult
-            save_nexus_show_adult(self._show_adult)
+            save_nexus_show_adult(not on)
         except Exception:
             pass
-        self._rebuild_cards()       # filter is applied at card-build time
+        self._page = 0
+        self._reload()
+
+    def _on_show_only_adult_toggled(self):
+        on = bool(self._show_only_adult_cb.state())
+        if on:
+            self._hide_adult_cb.set_state(0)
+        self._adult = True if on else None
+        self._page = 0
+        self._reload()
+
+    def _on_content_option_toggled(self):
+        self._supports_vortex = True if self._supports_vortex_cb.state() else None
+        self._has_updated = bool(self._only_updated_cb.state())
+        self._page = 0
+        self._reload()
 
     # -- search -------------------------------------------------------------
     def _on_search_mode_changed(self, label: str):
@@ -742,9 +1180,15 @@ class NexusBrowserView(QWidget):
             if w is not None:
                 w.deleteLater()
         self._cat_checks.clear()
+        # Advanced search filters (tags especially) are game-specific - reset
+        # them and force the tag list to reload for the new game.
+        self._tags_loaded = False
+        self._game_tags = []
+        self._reset_advanced_filter_state()
         self._update_section_buttons()
         self._update_browse_controls_visibility()
         self._load_categories()
+        self._load_tags()
         self._reload()
 
     def set_game(self, game, domain):
@@ -775,6 +1219,10 @@ class NexusBrowserView(QWidget):
         uploader_id = self._uploader_id
         cats = list(self._selected_categories) or None
         domain = self._domain
+        # Advanced filters only apply to the paged listing/search calls below
+        # (Tracked/Endorsed fetch by id list, not a ModsFilter search - same
+        # scoping the existing category filter already has).
+        filters = self._current_search_filters()
 
         def worker():
             entries = []
@@ -787,12 +1235,13 @@ class NexusBrowserView(QWidget):
                             entries = self._api.search_mods_by_uploader_id(
                                 domain, uploader_id, count=size,
                                 offset=page * size, category_names=cats,
-                                sort_key=sort_key)
+                                sort_key=sort_key, filters=filters)
                         else:
                             # Typed author search: match uploader by name.
                             entries = self._api.search_mods_by_author(
                                 domain, query, count=size, offset=page * size,
-                                category_names=cats, sort_key=sort_key)
+                                category_names=cats, sort_key=sort_key,
+                                filters=filters)
                         status = f"Mods by '{query}': page {page + 1} ({len(entries)} result(s))"
                     elif query.isdigit():
                         entries = self._api.search_mod_by_id(domain, int(query))
@@ -800,18 +1249,19 @@ class NexusBrowserView(QWidget):
                     else:
                         entries = self._api.search_mods(
                             domain, query, count=size, offset=page * size,
-                            category_names=cats, sort_key=sort_key)
+                            category_names=cats, sort_key=sort_key,
+                            filters=filters)
                         status = f"Search '{query}': page {page + 1} ({len(entries)} result(s))"
                 elif section == "Browse":
                     entries = self._api.get_top_mods(
                         domain, count=size, offset=page * size,
                         category_names=cats, created_since_days=time_days,
-                        sort_key=sort_key)
+                        sort_key=sort_key, filters=filters)
                     status = f"Browse: page {page + 1}"
                 elif section == "Trending":
                     entries = self._api.get_trending_mods_graphql(
                         domain, count=size, offset=page * size,
-                        category_names=cats)
+                        category_names=cats, filters=filters)
                     status = f"Trending (7 days): page {page + 1}"
                 elif section == "Tracked":
                     entries = self._fetch_user_mods(domain, self._api.get_tracked_mods)
@@ -884,10 +1334,13 @@ class NexusBrowserView(QWidget):
 
     # -- cards / grid -------------------------------------------------------
     def _visible_entries(self):
-        if self._show_adult:
+        """Client-side adult filter for Tracked/Endorsed (Browse/Trending
+        already get it server-side via NexusSearchFilters.adult)."""
+        if self._adult is None:
             return self._entries
+        want_adult = self._adult
         return [e for e in self._entries
-                if not getattr(e, "contains_adult_content", False)]
+                if bool(getattr(e, "contains_adult_content", False)) == want_adult]
 
     def _installed_ids(self) -> set:
         """Nexus mod IDs already installed in the active profile's staging for


### PR DESCRIPTION
## Summary

The Nexus mod browser's search was Categories + a plain "Show adult" checkbox - far short of what nexusmods.com's own search page offers. This adds the rest of the site's filter panel, backed by the same GraphQL `ModsFilter` schema the app already talks to for categories/sort/date:

- **Tags include/exclude** - autocompletes from the game's real tag vocabulary (via `legacyTags`, not the `tags` query, which despite the more obvious name only returns a couple dozen high-level meta tags rather than the full per-game list)
- **Language Support** - multi-select (OR'd together), plus "Hide translations"
- **Search Parameters** - title/description/author/uploader contains
- **Content Options** - Hide/Show-only adult content (mutually exclusive), Supported by Vortex, Show only updated mods
- **File Size / Downloads / Endorsements** - min/max dropdowns using the exact preset breakpoints the site's own dropdowns offer (not invented values)
- Each section is independently collapsible (open/close), matching the site's own accordion panel

## Why the extra host

Tag/language/size/downloads/endorsements filtering silently no-ops on `api.nexusmods.com/v2/graphql` (the host this app already used for search) - the filter parses fine but matches nothing. The site's own frontend calls a different host, `api-router.nexusmods.com/graphql`, where the same `ModsFilter` fields actually work. Only the public mods-listing/search calls (`get_top_mods`, `search_mods*`, `get_trending_mods_graphql`) were moved there; everything OAuth-gated (tracked/endorsed, downloads, collections, mutations) stays on the existing, proven host.

Adult-content filtering also moved server-side for Browse/Trending - it was previously client-side post-filtering, which silently shrank a page below the requested size instead of returning a full page of matching results.

## Test plan

- [x] Verified every new `ModsFilter` field (tag include/exclude, language OR, size/downloads/endorsements GTE/LTE, adult, supportsVortex, hasUpdated, description/author/uploader substring) against the live API with real games/mods
- [x] Confirmed the `legacyTags` fix against the reported bug (typing "2" now surfaces the same 8 matches the site shows, including "Version 1.6 Compatible")
- [x] Confirmed multi-language OR semantics and "Hide translations" (`excludedTag=Translation` on the site) against live results
- [x] Offscreen QTest-driven integration pass: collapsible sections, tag chips, adult mutual-exclusion, Vortex/updated toggles, and size/downloads dropdowns all exercised end-to-end against the real (unauthenticated) API, not mocks
- [x] `pyflakes` clean on both changed files
- [x] Manual test in the running app (done locally by the requester before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)