### PR TITLE
Fix destination path case sensitivity in Palworld.json

### DIFF
--- a/Custom Handlers/Palworld.json
+++ b/Custom Handlers/Palworld.json
@@ -123,7 +123,7 @@
       "flatten": true
     },
     {
-      "dest": "Binaries/Win64/ue4ss/Mods/PalSchema/Mods",
+      "dest": "Binaries/Win64/ue4ss/Mods/PalSchema/mods",
       "folders": [
         "appearance",
         "blueprints",


### PR DESCRIPTION
The correct path must be lowercase for the mods to be enabled