### PR TITLE
Displays step's name in FOMOD wizard

### DIFF
--- a/src/gui_qt/fomod_wizard_view.py
+++ b/src/gui_qt/fomod_wizard_view.py
@@ -81,6 +81,9 @@ class FomodWizardView(QWidget):
         title.setStyleSheet("font-size:15px; font-weight:600;")
         hb.addWidget(title)
         hb.addStretch(1)
+        self._step_name = QLabel("")
+        hb.addWidget(self._step_name)
+        hb.addStretch(1)
         self._step_lbl = QLabel("")
         self._step_lbl.setStyleSheet(f"color:{self._c('TEXT_DIM')};")
         hb.addWidget(self._step_lbl)
@@ -299,6 +302,7 @@ class FomodWizardView(QWidget):
         self._show_plugin(selected_plugin or first_plugin)
 
         total = len(self._visible_steps)
+        self._step_name.setText(step.name.strip())
         self._step_lbl.setText(self.tr("Step {0} of {1}").format(self._cur + 1, total))
         self._back_btn.setEnabled(self._cur > 0)
         self._next_btn.setText(self.tr("Finish") if self._cur >= total - 1 else self.tr("Next"))


### PR DESCRIPTION
Adds a new QLabel centered in the header of FOMOD wizard. It will display the current step's name.

Problem: I've noticed this missing feature when I've installed patches with FOMOD (JK's Interiors Patch Collection for example) where this name is useful to know what mod the patch will apply.

Proposed solution: I've added a new QLabel in the header, between the mod name and the step counter.

If this solution does not fit or break something else, let me know. I can do it another way.

(This is my first ever GitHub contribution. I hope I'm doing it right.)