### PR TITLE
Add Dawnwalker Engine.ini and Game.ini files

### DIFF
--- a/Custom Handlers/The_Blood_of_Dawnwalker.json
+++ b/Custom Handlers/The_Blood_of_Dawnwalker.json
@@ -97,6 +97,15 @@
         "mods.txt"
       ],
       "include_siblings": true
+    },
+    {
+      "dest": "drive_c/users/steamuser/AppData/Local/Dawnwalker/Saved/Config/Windows",
+      "filenames": [
+        "Engine.ini",
+        "Game.ini"
+      ],
+      "flatten": true,
+      "to_prefix": true
     }
   ],
   "restore_whitelist": [],


### PR DESCRIPTION
Perhaps this can be done for all Unreal Engine games as well. There's a [handful of other possible configuration files](https://dev.epicgames.com/documentation/unreal-engine/configuration-files-in-unreal-engine?lang=en-US#configurationfilesinyourproject), but this is what I currently use with my mod list.