### PR TITLE
Include loadorder.txt in profile backups

### DIFF
--- a/src/Utils/profiles/_selftest.py
+++ b/src/Utils/profiles/_selftest.py
@@ -1,0 +1,65 @@
+"""Focused regression tests for profile backup and restore.
+
+Run from the repository root with::
+
+    PYTHONPATH=src python3 -m Utils.profiles._selftest -v
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from Utils.profiles.backup import create_backup, restore_backup
+
+
+class ProfileBackupTests(unittest.TestCase):
+    def test_restore_includes_plugins_and_loadorder(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            profile_dir = Path(temporary) / "profile"
+            profile_dir.mkdir()
+            plugins = profile_dir / "plugins.txt"
+            loadorder = profile_dir / "loadorder.txt"
+            plugins.write_text("*Original.esp\n", encoding="utf-8")
+            loadorder.write_text("Original.esp\n", encoding="utf-8")
+
+            create_backup(profile_dir)
+            backup_dir = next((profile_dir / "backups").iterdir())
+            plugins.write_text("*Changed.esp\n", encoding="utf-8")
+            loadorder.write_text("Changed.esp\n", encoding="utf-8")
+
+            restore_backup(profile_dir, backup_dir)
+
+            self.assertEqual(
+                plugins.read_text(encoding="utf-8"), "*Original.esp\n")
+            self.assertEqual(
+                loadorder.read_text(encoding="utf-8"), "Original.esp\n")
+
+    def test_restore_old_backup_leaves_current_loadorder_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            profile_dir = Path(temporary) / "profile"
+            backup_dir = Path(temporary) / "old-backup"
+            profile_dir.mkdir()
+            backup_dir.mkdir()
+            (profile_dir / "plugins.txt").write_text(
+                "*Current.esp\n", encoding="utf-8")
+            (profile_dir / "loadorder.txt").write_text(
+                "Current.esp\n", encoding="utf-8")
+            (backup_dir / "plugins.txt").write_text(
+                "*Original.esp\n", encoding="utf-8")
+
+            restore_backup(profile_dir, backup_dir)
+
+            self.assertEqual(
+                (profile_dir / "plugins.txt").read_text(encoding="utf-8"),
+                "*Original.esp\n",
+            )
+            self.assertEqual(
+                (profile_dir / "loadorder.txt").read_text(encoding="utf-8"),
+                "Current.esp\n",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Utils/profiles/backup.py
+++ b/src/Utils/profiles/backup.py
@@ -29,6 +29,7 @@ _SEPARATOR_SUFFIX = "_separator"
 _BACKUP_FILES = [
     "modlist.txt",
     "plugins.txt",
+    "loadorder.txt",
     "userlist.yaml",
     "profile_state.json",
     # Legacy individual files - kept so old backups can still be restored

--- a/src/Utils/profiles/meson.build
+++ b/src/Utils/profiles/meson.build
@@ -1,5 +1,6 @@
 py.install_sources(
   '__init__.py',
+  '_selftest.py',
   'backup.py',
   'convert.py',
   'curated.py',


### PR DESCRIPTION
## Summary

Include `loadorder.txt` when creating and restoring profile backups.

Profile backups already preserved `plugins.txt`, but omitted its companion `loadorder.txt`. As a result, restoring a backup could restore plugin state while leaving the newer load order in place.

## Changes

- Add `loadorder.txt` to the profile backup file list
- Add regression coverage for backup/restore of plugin load order
- Verify compatibility with older backups that do not contain `loadorder.txt`
- Register the profile self-test with Meson

## Tests

```text
PYTHONPATH=src python3 -m Utils.profiles._selftest -v

Ran 2 tests
OK