### PR TITLE
Fail AppImage downloads on HTTP errors

### DIFF
--- a/src/appimage/Amethyst-MM-installer.sh
+++ b/src/appimage/Amethyst-MM-installer.sh
@@ -114,7 +114,7 @@ fi
 APPIMAGE_TMP="$APPIMAGE_DEST.new"
 echo "Downloading AppImage..."
 if command -v curl &>/dev/null; then
-    curl -L -o "$APPIMAGE_TMP" "$APPIMAGE_URL"
+    curl --fail --show-error --location -o "$APPIMAGE_TMP" "$APPIMAGE_URL"
 elif command -v wget &>/dev/null; then
     wget -O "$APPIMAGE_TMP" "$APPIMAGE_URL"
 else
@@ -135,7 +135,7 @@ fi
 # Download icon
 echo "Downloading icon..."
 if command -v curl &>/dev/null; then
-    curl -L -o "$ICONS_DIR/$ICON_NAME" "$ICON_URL"
+    curl --fail --show-error --location -o "$ICONS_DIR/$ICON_NAME" "$ICON_URL"
 elif command -v wget &>/dev/null; then
     wget -O "$ICONS_DIR/$ICON_NAME" "$ICON_URL"
 fi


### PR DESCRIPTION
## Summary

Prevent HTTP error responses from being treated as successful AppImage or icon downloads.

`curl` returns success for HTTP 4xx/5xx responses by default. This meant that a 404/500 response body could be written to the temporary AppImage and then replace the existing executable.

## Changes

- Add `--fail --show-error --location` to the AppImage curl download
- Apply the same handling to the icon curl download

## Verification

Before the fix:

```text
404 -> curl exit 0 -> existing AppImage replaced by error response
500 -> curl exit 0 -> existing AppImage replaced by error response
200 -> curl exit 0 -> successful replacement