### PR TITLE
Fix false Flatpak sandbox warning for /var/mnt paths (#510)

### DIFF
--- a/flatpak/io.github.Amethyst.ModManager.yml
+++ b/flatpak/io.github.Amethyst.ModManager.yml
@@ -44,6 +44,7 @@ build-options:
 #   XDG_CONFIG_HOME, so it lands in ~/.var/app/<app-id>/config/AmethystModManager
 #   (separate from a native/AppImage install's ~/.config/AmethystModManager).
 # - run/media, media, mnt: Steam libraries on SD cards and removable drives (Steam Deck, etc.)
+# - var/mnt: mount point on Fedora Atomic / Bazzite, where /mnt is a symlink to /var/mnt
 # - ~/.var/app/com.valvesoftware.Steam: Steam Flatpak data (home excludes ~/.var/app)
 # - ~/.var/app/com.heroicgameslauncher.hgl: Heroic Flatpak
 # - ~/.var/app/net.lutris.Lutris: Lutris Flatpak (pga.db, game configs, wine runners)
@@ -60,6 +61,7 @@ finish-args:
   - --filesystem=/run/media
   - --filesystem=/media
   - --filesystem=/mnt
+  - --filesystem=/var/mnt
   - --filesystem=~/.var/app/com.valvesoftware.Steam
   - --filesystem=~/.var/app/com.heroicgameslauncher.hgl
   - --filesystem=~/.var/app/net.lutris.Lutris

--- a/src/Utils/environment/sandbox.py
+++ b/src/Utils/environment/sandbox.py
@@ -1,7 +1,8 @@
 """Detect user-supplied paths that the Flatpak sandbox cannot see.
 
-The manager's flatpak grants --filesystem=home, /run/media, /media, /mnt and
-the Steam/Heroic flatpak data dirs (see flatpak/io.github.Amethyst.ModManager.yml).
+The manager's flatpak grants --filesystem=home, /run/media, /media, /mnt,
+/var/mnt and the Steam/Heroic flatpak data dirs (see
+flatpak/io.github.Amethyst.ModManager.yml).
 A game or staging path outside those trees (e.g. /data/SteamLibrary, /opt/...)
 simply doesn't exist from inside the sandbox - indistinguishable from a typo -
 so the UI should tell the user it's a sandbox grant problem, not a bad path.
@@ -19,8 +20,12 @@ from pathlib import Path
 _GRANTED_VAR_APPS = ("com.valvesoftware.Steam", "com.heroicgameslauncher.hgl",
                      "net.lutris.Lutris", "io.github.Faugus.faugus-launcher")
 
-# Non-home trees granted in the manifest.
-_GRANTED_ROOTS = ("/run/media", "/media", "/mnt")
+# Non-home trees granted in the manifest. /var/mnt is included because on
+# Fedora Atomic / Bazzite (and similar) /mnt is a symlink to /var/mnt, so the
+# --filesystem=/mnt grant actually exposes /var/mnt, and Path.resolve() rewrites
+# any /mnt/... path the user picks to its /var/mnt/... target. Without it such a
+# resolved path looks unreachable and triggers a false "not visible" warning.
+_GRANTED_ROOTS = ("/run/media", "/media", "/mnt", "/var/mnt")
 
 
 def in_flatpak() -> bool:


### PR DESCRIPTION
## Problem

On Fedora Atomic / Bazzite (and similar immutable distros), `/mnt` is a symlink to `/var/mnt`. The Flatpak manifest grants `--filesystem=/mnt`, which therefore already exposes `/var/mnt`, and `Path.resolve()` rewrites any `/mnt/...` path the user picks to its `/var/mnt/...` target.

However, `sandbox.py`'s reachability check only listed `/mnt` in `_GRANTED_ROOTS`. So a resolved `/var/mnt/...` staging or game path was flagged as *"This path is not visible inside the Flatpak sandbox"* even though the folder is fully accessible — blocking game setup. Picking `/mnt/...` hit the same wall because it resolves to `/var/mnt/...`.

Reported and root-caused in #510.

## Fix

- Add `/var/mnt` to `_GRANTED_ROOTS` in `src/Utils/environment/sandbox.py`.
- Grant `/var/mnt` explicitly in the Flatpak manifest (belt-and-suspenders for setups where `/var/mnt` is a real mount independent of the `/mnt` symlink).

## Verification

Simulated the in-sandbox path check:

| Path | Before | After |
|------|--------|-------|
| `/var/mnt/.../staging/SkyrimSE` | ⚠️ false warning | ✅ no warning |
| `/mnt/.../staging/SkyrimSE` | ✅ no warning | ✅ no warning |
| `/run/media/deck/SD/games` | ✅ no warning | ✅ no warning |
| `/opt/SteamLibrary/game` (genuinely ungranted) | ⚠️ warns | ⚠️ warns (no regression) |
| `/data/SteamLibrary/game` (genuinely ungranted) | ⚠️ warns | ⚠️ warns (no regression) |

Genuinely ungranted paths still correctly surface the sandbox hint.

Fixes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)