### PR TITLE
Fix false Flatpak sandbox warning for /var/mnt paths

### DIFF
--- a/flatpak/io.github.Amethyst.ModManager.yml
+++ b/flatpak/io.github.Amethyst.ModManager.yml
@@ -49,6 +49,7 @@ build-options:
 #   XDG_CONFIG_HOME, so it lands in ~/.var/app/<app-id>/config/AmethystModManager
 #   (separate from a native/AppImage install's ~/.config/AmethystModManager).
 # - run/media, media, mnt: Steam libraries on SD cards and removable drives (Steam Deck, etc.)
+# - var/mnt: mount point on Fedora Atomic / Bazzite, where /mnt is a symlink to /var/mnt
 # - ~/.var/app/com.valvesoftware.Steam: Steam Flatpak data (home excludes ~/.var/app)
 # - ~/.var/app/com.heroicgameslauncher.hgl: Heroic Flatpak
 # - ~/.var/app/net.lutris.Lutris: Lutris Flatpak (pga.db, game configs, wine runners)
@@ -65,6 +66,7 @@ finish-args:
   - --filesystem=/run/media
   - --filesystem=/media
   - --filesystem=/mnt
+  - --filesystem=/var/mnt
   - --filesystem=~/.var/app/com.valvesoftware.Steam
   - --filesystem=~/.var/app/com.heroicgameslauncher.hgl
   - --filesystem=~/.var/app/net.lutris.Lutris

--- a/src/Utils/environment/_sandbox_selftest.py
+++ b/src/Utils/environment/_sandbox_selftest.py
@@ -1,0 +1,96 @@
+"""Regression tests for :mod:`Utils.environment.sandbox`.
+
+Guards the Flatpak reachability hint against a false positive on Fedora Atomic /
+Bazzite, where ``/mnt`` is a symlink to ``/var/mnt``: the ``--filesystem=/mnt``
+grant already exposes ``/var/mnt`` and ``Path.resolve()`` rewrites any
+``/mnt/...`` path to its ``/var/mnt/...`` target, so a resolved ``/var/mnt/...``
+staging or game path must NOT be flagged as unreachable. Genuinely ungranted
+trees (``/opt``, ``/data``, ...) must still surface the grant hint.
+
+The check drives ``flatpak_blocked_path_hint`` directly with ``in_flatpak``
+forced on and paths that do not exist on the test host (so the granted-root
+logic is exercised rather than the early "path exists" return). No runtime
+dependencies beyond the module under test.
+
+Run with::
+
+    PYTHONPATH=src python3 -m Utils.environment._sandbox_selftest
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from Utils.environment import sandbox
+
+
+@contextmanager
+def _pretend_flatpak():
+    """Force the in-sandbox branch regardless of the real host."""
+    original = sandbox.in_flatpak
+    sandbox.in_flatpak = lambda: True
+    try:
+        yield
+    finally:
+        sandbox.in_flatpak = original
+
+
+# Deep, non-existent paths so p.exists() is False and the granted-root logic
+# (not the early "reachable" return) is what actually decides.
+_GRANTED_PATHS = (
+    "/var/mnt/D/ModManagers/Amethyst/staging/SkyrimSE",
+    "/mnt/D/ModManagers/Amethyst/staging/SkyrimSE",
+    "/run/media/deck/SD/SteamLibrary/game",
+    "/media/user/Drive/SteamLibrary/game",
+)
+_UNGRANTED_PATHS = (
+    "/opt/SteamLibrary/game",
+    "/data/SteamLibrary/game",
+    "/srv/games/game",
+)
+
+
+def test_var_mnt_is_treated_as_granted() -> None:
+    with _pretend_flatpak():
+        hint = sandbox.flatpak_blocked_path_hint(
+            "/var/mnt/D/ModManagers/Amethyst/staging/SkyrimSE")
+    assert hint is None, (
+        "/var/mnt path (granted via the /mnt symlink) must not be flagged as "
+        f"unreachable, got: {hint!r}")
+    print("✓ /var/mnt paths are recognised as granted (no false warning)")
+
+
+def test_granted_roots_never_warn() -> None:
+    with _pretend_flatpak():
+        for path in _GRANTED_PATHS:
+            assert sandbox.flatpak_blocked_path_hint(path) is None, (
+                f"granted root path unexpectedly flagged: {path}")
+    print("✓ all granted-root trees stay silent")
+
+
+def test_ungranted_paths_still_warn() -> None:
+    with _pretend_flatpak():
+        for path in _UNGRANTED_PATHS:
+            hint = sandbox.flatpak_blocked_path_hint(path)
+            assert hint is not None and "flatpak override" in hint, (
+                f"genuinely ungranted path should still warn: {path} -> {hint!r}")
+    print("✓ genuinely ungranted paths still surface the grant hint")
+
+
+def test_var_mnt_in_granted_roots_constant() -> None:
+    # The constant and the manifest grant must stay in step; a bare membership
+    # check catches an accidental revert of the tuple.
+    assert "/var/mnt" in sandbox._GRANTED_ROOTS
+    print("✓ /var/mnt is present in _GRANTED_ROOTS")
+
+
+def main() -> None:
+    test_var_mnt_in_granted_roots_constant()
+    test_var_mnt_is_treated_as_granted()
+    test_granted_roots_never_warn()
+    test_ungranted_paths_still_warn()
+    print("All sandbox self-tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Utils/environment/sandbox.py
+++ b/src/Utils/environment/sandbox.py
@@ -1,7 +1,8 @@
 """Detect user-supplied paths that the Flatpak sandbox cannot see.
 
-The manager's flatpak grants --filesystem=home, /run/media, /media, /mnt and
-the Steam/Heroic flatpak data dirs (see flatpak/io.github.Amethyst.ModManager.yml).
+The manager's flatpak grants --filesystem=home, /run/media, /media, /mnt,
+/var/mnt and the Steam/Heroic flatpak data dirs (see
+flatpak/io.github.Amethyst.ModManager.yml).
 A game or staging path outside those trees (e.g. /data/SteamLibrary, /opt/...)
 simply doesn't exist from inside the sandbox - indistinguishable from a typo -
 so the UI should tell the user it's a sandbox grant problem, not a bad path.
@@ -19,8 +20,12 @@ from pathlib import Path
 _GRANTED_VAR_APPS = ("com.valvesoftware.Steam", "com.heroicgameslauncher.hgl",
                      "net.lutris.Lutris", "io.github.Faugus.faugus-launcher")
 
-# Non-home trees granted in the manifest.
-_GRANTED_ROOTS = ("/run/media", "/media", "/mnt")
+# Non-home trees granted in the manifest. /var/mnt is included because on
+# Fedora Atomic / Bazzite (and similar) /mnt is a symlink to /var/mnt, so the
+# --filesystem=/mnt grant actually exposes /var/mnt, and Path.resolve() rewrites
+# any /mnt/... path the user picks to its /var/mnt/... target. Without it such a
+# resolved path looks unreachable and triggers a false "not visible" warning.
+_GRANTED_ROOTS = ("/run/media", "/media", "/mnt", "/var/mnt")
 
 
 def in_flatpak() -> bool:


### PR DESCRIPTION
**What:** On Fedora Atomic / Bazzite (and similar immutable distros) `/mnt` is a symlink to `/var/mnt`. The Flatpak manifest grants `--filesystem=/mnt`, which therefore already exposes `/var/mnt`, and `Path.resolve()` rewrites any `/mnt/...` path the user picks to its `/var/mnt/...` target. But `sandbox.flatpak_blocked_path_hint()` only listed `/mnt` in `_GRANTED_ROOTS`, so a resolved `/var/mnt/...` staging or game path was flagged as *"This path is not visible inside the Flatpak sandbox"* and game setup was blocked — even though the folder is fully accessible. Picking `/mnt/...` hit the same wall because it resolves to `/var/mnt/...`.

**Why it's a bug:** The path is genuinely reachable (the reporter confirmed the sandbox can `mkdir`/`rmdir` there), so the reachability check produces a false positive that stops the user from adding a game. Reported and root-caused in #510.

**Fix:**
- Add `/var/mnt` to `_GRANTED_ROOTS` in `src/Utils/environment/sandbox.py`.
- Grant `/var/mnt` explicitly in the Flatpak manifest, so it also works where `/var/mnt` is a real mount independent of the `/mnt` symlink.

**Test:** Adds `src/Utils/environment/_sandbox_selftest.py`, a dependency-free regression test following the repo's `_selftest.py` convention. It forces `in_flatpak` on and drives `flatpak_blocked_path_hint` with non-existent paths so the granted-root logic (not the early "path exists" return) is what decides:

| Path | Result |
|------|--------|
| `/var/mnt/.../staging/SkyrimSE` | no warning (fixed) |
| `/mnt/...`, `/run/media/...`, `/media/...` | no warning |
| `/opt/...`, `/data/...`, `/srv/...` (genuinely ungranted) | still warns (no regression) |

Run:
```
PYTHONPATH=src python3 -m Utils.environment._sandbox_selftest
```
Verified: passes with the fix; the granted-root assertions fail if `/var/mnt` is reverted out of `_GRANTED_ROOTS`.

Fixes #510

---

*Assisted-by: Claude (claude-opus-4-8)*