### PR TITLE
Fix missing conflict_blacklist.py causing deploy/restore failures in 2.5.0-beta.4

### DIFF
--- a/src/Utils/games/meson.build
+++ b/src/Utils/games/meson.build
@@ -1,5 +1,6 @@
 py.install_sources(
   '__init__.py',
+  'conflict_blacklist.py',
   'discovery.py',
   'frameworks.py',
   'quick_configure.py',


### PR DESCRIPTION
## Summary
- `Utils/filegraph/adapter.py` imports `Utils.games.conflict_blacklist.effective_rules` (`_refresh_blacklist`), but `src/Utils/games/meson.build` never listed `conflict_blacklist.py` in its `py.install_sources()`.
- The file exists in the source tree and is used at runtime, but is never copied into the installed package, so any build from this branch (including the `v2.5.0-beta.4` Flatpak) fails on any deploy/restore path that touches file-graph state:
  ```
  ModuleNotFoundError: No module named 'Utils.games.conflict_blacklist'
  ```
- This one-line fix adds it to the install list, matching the other files in that directory.

## Test plan
- [ ] Build the Flatpak (or run `meson install`) from this branch and confirm `Utils/games/conflict_blacklist.py` is present in the installed `site-packages`.
- [ ] Confirm Deploy and Restore no longer raise `ModuleNotFoundError: No module named 'Utils.games.conflict_blacklist'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWuM6MXZhDwBLVfapSML2W